### PR TITLE
Updated GDB location for darwin

### DIFF
--- a/liteidex/os_deploy/macosx/liteenv/darwin64.env
+++ b/liteidex/os_deploy/macosx/liteenv/darwin64.env
@@ -8,7 +8,7 @@ CGO_ENABLED=1
 
 PATH=$GOBIN:$GOROOT/bin:$PATH
 
-LITEIDE_GDB=gdb
+LITEIDE_GDB=/usr/local/bin/gdb
 LITEIDE_MAKE=make
 LITEIDE_TERM=/usr/bin/open
 LITEIDE_TERMARGS=-a Terminal


### PR DESCRIPTION
The latest version of GDB for the mac always installed in usr/local/bin.
