### PR TITLE
Fix for case sensitive path comparison on windows

### DIFF
--- a/liteidex/src/utils/fileutil/fileutil.cpp
+++ b/liteidex/src/utils/fileutil/fileutil.cpp
@@ -45,7 +45,11 @@ bool FileUtil::compareFile(const QString &fileName1, const QString &fileName2, b
         return false;
     }
     if (canonical) {
+#if defined(WIN32)
+        return (QFileInfo(fileName1).canonicalFilePath().compare(QFileInfo(fileName2).canonicalFilePath(), Qt::CaseInsensitive) == 0);
+#else
         return QFileInfo(fileName1).canonicalFilePath() == QFileInfo(fileName2).canonicalFilePath();
+#endif
     }
     return QFileInfo(fileName1).filePath() == QFileInfo(fileName2).filePath();
 }


### PR DESCRIPTION
Proposed workaround for the go-caused issue described in #122 and, possibly, in #72.

This ensures that on windows systems the comparsion of the canonical paths does not care for lower case or upper case paths, as both are considered to be equal in Windows sytems.
