### PR TITLE
Fixing Test to only test the open go source code file

### DIFF
--- a/liteidex/deploy/litebuild/gosrc.xml
+++ b/liteidex/deploy/litebuild/gosrc.xml
@@ -18,7 +18,7 @@
 		<action id="FileRun" menu="BuildAndRun" img="gray/filerun.png" key="Alt+F6" cmd="$(GO)" args="run $(EDITOR_NAME)" save="editor" output="true" codec="utf-8" readline="true"/>
 		<action id="Get" img="blue/get.png" cmd="$(GO)" args="get -v ." save="all" output="true" codec="utf-8"/>
 		<action id="Get Force" menu="Get" img="blue/get.png" cmd="$(GO)" args="get -u -v ." save="all" output="true" codec="utf-8"/>
-		<action id="Test" img="blue/test.png" key = "Ctrl+T" cmd="$(GO)" args="test -v" save="all" output="true" codec="utf-8" regex="$(ERRREGEX)" navigate="true"/>
+		<action id="Test" img="blue/test.png" key = "Ctrl+T" cmd="$(GO)" args="test -v $(EDITOR_NAME)" save="all" output="true" codec="utf-8" regex="$(ERRREGEX)" navigate="true"/>
 		<action id="Bench" menu="Test" img="blue/testbench.png" cmd="$(GO)" args="test -test.bench=.*" save="all" output="true" codec="utf-8" regex="$(ERRREGEX)" navigate="true"/>
 		<action id="Fmt" menu="Test" img="blue/fmt.png" cmd="$(GO)" args="fmt" save="all" output="true" regex="$(ERRREGEX)" navigate="true"/>
 		<action id="Vet" menu="Test" img="blue/vet.png" cmd="$(GO)" args="vet" save="all" output="true" regex="$(ERRREGEX)" navigate="true"/>


### PR DESCRIPTION
I have folders with multiple test files to help keep things organized. This will only have the Test command run go test against the current open go file.
