### PR TITLE
Fix a typo in finddocwidget.cpp

### DIFF
--- a/liteidex/src/plugins/golangdoc/finddocwidget.cpp
+++ b/liteidex/src/plugins/golangdoc/finddocwidget.cpp
@@ -43,7 +43,7 @@
 //lite_memory_check_end
 
 static char help[] =
-"<b>Serach Format</b>"
+"<b>Search Format</b>"
 "<pre>"
 "fmt.\n"
 "    Extracts all fmt pkg symbol document\n"
@@ -54,7 +54,7 @@ static char help[] =
 "Println\n"
 "    Extracts fmt.Println log.Println log.Logger.Println etc"
 "</pre>"
-"<b>Serach Option</b>"
+"<b>Search Option</b>"
 "<pre>"
 "Match Word.\n"
 "    Match whole world only\n"


### PR DESCRIPTION
Fixed a couple of typos in liteidex/src/plugins/golangdoc/finddocwidget.cpp, in static char help[]
    "<b>Serach Format</b>"
and
    "<b>Serach Option</b>"
