### PR TITLE
Update filesystemwidget.cpp

### DIFF
--- a/liteidex/src/utils/filesystem/filesystemwidget.cpp
+++ b/liteidex/src/utils/filesystem/filesystemwidget.cpp
@@ -447,6 +447,7 @@ void FileSystemWidget::openShell()
     QString cmd = env.value("LITEIDE_TERM");
     QStringList args = env.value("LITEIDE_TERMARGS").split(" ");
     QString path = dir.path();
+    args.append(path);
 #ifdef Q_OS_WIN
     if (path.length() == 2 && path.right(1) == ":") {
         path += "/";


### PR DESCRIPTION
QProcess::startDetached(cmd,args,path) seems to have ignored the `path` in my homebrew'ed liteide, and homebrew'ed qt. This is a workaround to add the path as the last argument.
