### PR TITLE
gosrc.xml : use a more generic regexpr to match file/line numbers

### DIFF
--- a/liteidex/deploy/litebuild/gosrc.xml
+++ b/liteidex/deploy/litebuild/gosrc.xml
@@ -3,7 +3,7 @@
 	<mime-type type="text/x-gosrc" id="gosrc" work="$(EDITOR_DIR)" ver="1">
 		<config id="Go" name="GO" value="go"/>
 		<config id="LiteIDEStub" name="LITEIDESTUB" value="$(LITEAPPDIR)/liteide_stub"/>
-		<config id="ErrRegex" name="ERRREGEX" value="\b((?:[a-zA-Z]:)?[\w\d_\-\\\/\.]+):(\d+)\b"/>
+		<config id="ErrRegex" name="ERRREGEX" value="((?:[a-zA-Z]:)?[\w\d_\-\\\/\.]+):(\d+)\b"/>
 		<custom id="TargetArgs" name="TARGETARGS" value=""/>
 		<custom id="BuildArgs" name="BUILDARGS" value=""/>
 		<custom id="InstallArgs" name="INSTALLARGS" value=""/>


### PR DESCRIPTION
This way liteide can also find the correct file when using testing libraries such as [github.com/stretchr/testify](https://github.com/stretchr/testify).
For example it was not previously possible to open myfile_test.go with the folowing log in the console :

```
=== RUN TestAssertLib
--- FAIL: TestAssertLib (0.00 seconds)
    assertions.go:156:

    Location:   myfile_test.go:348

    Error:      test failure

FAIL
exit status 1
```
