### PR TITLE
Make sure shortcuts work all the time by adding all QAction with shortcuts to main window's widget

### DIFF
--- a/liteidex/src/liteapp/actionmanager.cpp
+++ b/liteidex/src/liteapp/actionmanager.cpp
@@ -367,6 +367,11 @@ void ActionContext::regAction(QAction *act, const QString &id, const QString &de
             act->setToolTip(QString("%1 (%2)").arg(act->text()).arg(info->ks));
         }
         info->action = act;
+
+        // Add QAction to main window, otherwise the shortcut doesn't always work
+        if (!defks.isEmpty()) {
+            m_liteApp->mainWindow()->addAction(act);
+        }
     } else {
         info->action = 0;
     }


### PR DESCRIPTION
The shortcuts (such as Cltr+W, Cltr+Q, etc) not always work (at least on Ubuntu 14.10 with Qt5). This behavior is observed when QAction isn't added to a widget that's always listening for events (such as the main window). This patch adds every QAction with shortcut to main window's widget, making sure it works all the time.
