### PR TITLE
golang.org/x/tools/astutil was moved to golang.org/x/tools/go/ast/astutil

### DIFF
--- a/liteidex/src/liteide_stub/fix.go
+++ b/liteidex/src/liteide_stub/fix.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/tools/astutil"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 // importToGroup is a list of functions which map from an import path to

--- a/liteidex/src/liteide_stub/imports.go
+++ b/liteidex/src/liteide_stub/imports.go
@@ -20,7 +20,7 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/tools/astutil"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 // Options specifies options for processing files.


### PR DESCRIPTION
### Reference
* [[tools] astutil: move to go/astutil](https://groups.google.com/forum/#!topic/golang-codereviews/SHvYxM-5mzg)
* [astutil: move to go/ast/astutil](https://go-review.googlesource.com/#/c/2592/)

