### PR TITLE
fixed: Drag the file into the editor, but not open file.

### DIFF
--- a/liteidex/src/plugins/liteeditor/liteeditorwidget.cpp
+++ b/liteidex/src/plugins/liteeditor/liteeditorwidget.cpp
@@ -56,6 +56,7 @@ LiteEditorWidget::LiteEditorWidget(LiteApi::IApplication *app, QWidget *parent) 
     m_scrollWheelZooming(true),
     m_bSpellCheckZoneDontComplete(false)
 {
+    setAcceptDrops(false);
     this->m_averageCharWidth = QFontMetrics(this->font()).averageCharWidth();
 }
 


### PR DESCRIPTION
When drag file into the editor, then editor displays the file path, which actually the editor should open the file.
![screenshot from 2015-02-21 00 49 09](https://cloud.githubusercontent.com/assets/1155104/6306186/e5f8ebb4-b963-11e4-93a2-ca6ab8c8d0cc.png)

Note: I found this problem on Linux Mint cinnamon 17 and Linux Mint mate 17.