### PR TITLE
Updated the instruction of installing Qt on Mac OS X. Greatly reduced the installation time on Mac OS X.

### DIFF
--- a/liteidex/deploy/welcome/en/install.md
+++ b/liteidex/deploy/welcome/en/install.md
@@ -17,7 +17,7 @@ Download the archive and extract it into c:\
 Download the archive and extract it into /usr/local or $HOME
 
 ## Building from Source
-Source code for LiteIDE can be found at <https://github.com/visualfc/liteide>.  You will need to install Qt4/Qt5 in order to compile the source.  Qt can be obtained from <https://qt-project.org/downloads> or from your distribution's package manager. 
+Source code for LiteIDE can be found at <https://github.com/visualfc/liteide>.  You will need to install Qt4/Qt5 in order to compile the source.  Qt can be obtained from <https://qt-project.org/downloads> or from your distribution's package manager. For Mac OS X, you don't need to install Qt from source code, but run `brew update && brew install qt` which will save you several hours.
 
 ### Windows
 	> git clone https://github.com/visualfc/liteide.git
@@ -50,7 +50,7 @@ Source code for LiteIDE can be found at <https://github.com/visualfc/liteide>.  
 
 ### Mac OS X
 	$ git clone https://github.com/visualfc/liteide.git
-	$ export QTDIR=$HOME/QtSDK/Desktop/Qt/484/gcc
+	$ export QTDIR=$HOME/QtSDK/Desktop/Qt/484/gcc #If QT is installed with brew, input: export QTDIR=/usr/local/Cellar/qt/4.8.6
 	$ cd liteide/build
 	$ ./update_pkg.sh
 	$ ./build_osx.sh

--- a/liteidex/deploy/welcome/zh_CN/install.md
+++ b/liteidex/deploy/welcome/zh_CN/install.md
@@ -18,7 +18,7 @@
 下载压缩包并解压到/usr/local或者是$HOME
 
 ## 从源代码编译
-LiteIDE源码位于<https://github.com/visualfc/liteide>上。需要使用Qt4/Qt5来编译源代码，Qt库可以从<https://qt-project.org/downloads>上获取。下面的编译以Qt4为例。
+LiteIDE源码位于<https://github.com/visualfc/liteide>上。需要使用Qt4/Qt5来编译源代码，Qt库可以从<https://qt-project.org/downloads>上获取。Mac OS X用户可以不从源代码编译Qt，直接在终端中运行`brew update && brew install qt`，节省大量时间。下面的编译以Qt4为例。
 
 ### Windows
 	> git clone https://github.com/visualfc/liteide.git
@@ -39,7 +39,7 @@ LiteIDE源码位于<https://github.com/visualfc/liteide>上。需要使用Qt4/Qt
 
 ### Mac OS X
 	$ git clone https://github.com/visualfc/liteide.git
-	$ export QTDIR=$HOME/QtSDK/Desktop/Qt/484/gcc
+	$ export QTDIR=$HOME/QtSDK/Desktop/Qt/484/gcc #如果Qt是通过brew安装，输入: export QTDIR=/usr/local/Cellar/qt/4.8.6
 	$ cd liteide/build
 	$ ./update_pkg.sh
 	$ ./build_osx.sh


### PR DESCRIPTION
Installing Qt by downloading and compiling source code is very painful and time-consuming. On Mac OS X, we can just run `brew update && brew install qt`.