### PR TITLE
Spelling + Grammar

### DIFF
--- a/liteidex/liteide_de.ts
+++ b/liteidex/liteide_de.ts
@@ -1735,7 +1735,7 @@ Bei „Ja“ gehen Ihre ungesicherten Änderungen verloren.</translation>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -2505,8 +2505,8 @@ wenn die darunter liegende Datei verändert oder gelöscht wurde.</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/liteidex/liteide_fr.ts
+++ b/liteidex/liteide_fr.ts
@@ -1653,7 +1653,7 @@ Do you want to reload the file from disk?</source>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -2381,8 +2381,8 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/liteidex/liteide_ja.ts
+++ b/liteidex/liteide_ja.ts
@@ -1728,7 +1728,7 @@ Answering &quot;Yes&quot; will discard your unsaved changes.</source>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -2497,8 +2497,8 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/liteidex/liteide_ru.ts
+++ b/liteidex/liteide_ru.ts
@@ -1736,7 +1736,7 @@ Answering &quot;Yes&quot; will discard your unsaved changes.</source>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -2481,8 +2481,8 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/liteidex/liteide_uk.ts
+++ b/liteidex/liteide_uk.ts
@@ -1752,7 +1752,7 @@ Answering &quot;Yes&quot; will discard your unsaved changes.</source>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation type="unfinished">Авто-оновлення потребує package коли код змінено.</translation>
     </message>
@@ -2497,8 +2497,8 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/liteidex/liteide_zh.ts
+++ b/liteidex/liteide_zh.ts
@@ -1740,7 +1740,7 @@ Answering &quot;Yes&quot; will discard your unsaved changes.</source>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation>自动更新依赖库当其源码改变时.</translation>
     </message>
@@ -2528,8 +2528,8 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation>允许鼠标滚轮导航Tabs</translation>
     </message>
     <message>

--- a/liteidex/liteide_zh_TW.ts
+++ b/liteidex/liteide_zh_TW.ts
@@ -1661,7 +1661,7 @@ Do you want to reload the file from disk?</source>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
+        <source>Auto update depends package when its source is changed.</source>
         <oldsource>Auto update depends package when source changed.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -2393,8 +2393,8 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
-        <source>Enalbe mouse whell navigation on tabs</source>
-        <oldsource>Enalbe mouse whell selected on tab</oldsource>
+        <source>Enable mouse wheel navigation on tabs</source>
+        <oldsource>Enable mouse wheel selected on tab</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/liteidex/src/liteapp/liteappoption.ui
+++ b/liteidex/src/liteapp/liteappoption.ui
@@ -345,7 +345,7 @@
           <item>
            <widget class="QCheckBox" name="editorTabsEnableWhellCheckBox">
             <property name="text">
-             <string>Enalbe mouse whell navigation on tabs</string>
+             <string>Enable mouse wheel navigation on tabs</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Fixed two misspelled English words in translations and minor grammatical error.

Specifically:

- `Enalbe` should be `Enable`
- `whell` should be `wheel`
- `it's` means "it is" and does not make sense in the context (http://www.its-not-its.info)