### PR TITLE
Use correct terminal on KDE desktops.

### DIFF
--- a/liteidex/os_deploy/linux/liteenv/cross-arm5.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-arm5.env
@@ -18,4 +18,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-arm6.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-arm6.env
@@ -18,4 +18,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-darwin32.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-darwin32.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-darwin64.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-darwin64.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-freebsd32.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-freebsd32.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-freebsd64.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-freebsd64.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-win32.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-win32.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/cross-win64.env
+++ b/liteidex/os_deploy/linux/liteenv/cross-win64.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/linux32-local.env
+++ b/liteidex/os_deploy/linux/liteenv/linux32-local.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/linux32.env
+++ b/liteidex/os_deploy/linux/liteenv/linux32.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/linux64-local.env
+++ b/liteidex/os_deploy/linux/liteenv/linux64-local.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/linux64.env
+++ b/liteidex/os_deploy/linux/liteenv/linux64.env
@@ -17,4 +17,4 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm

--- a/liteidex/os_deploy/linux/liteenv/system.env
+++ b/liteidex/os_deploy/linux/liteenv/system.env
@@ -17,5 +17,5 @@ LITEIDE_TERMARGS=
 LITEIDE_EXEC=/usr/bin/xterm
 LITEIDE_EXECOPT=-e
 
-LITEIDE_SHELL=gnome-terminal;lxterminal;kconsole;xfce4-terminal;xterm
+LITEIDE_SHELL=gnome-terminal;lxterminal;konsole;xfce4-terminal;xterm
 


### PR DESCRIPTION
KDE terminal app is 'konsole', not 'kconsole'. Changing the LITEIDE_SHELL variable in the .env files opens the correct terminal.