### PR TITLE
Fix typo in oracle command call.

### DIFF
--- a/liteidex/src/plugins/golangedit/golangedit.cpp
+++ b/liteidex/src/plugins/golangedit/golangedit.cpp
@@ -811,7 +811,7 @@ void GolangEdit::oracleWhat()
 
 void GolangEdit::oracleCallees()
 {
-    runOracle("calless");
+    runOracle("callees");
 }
 
 void GolangEdit::oracleCallers()


### PR DESCRIPTION
Hi there,

Using the IDE i noticed a typo in the oracle callees command.
So this fixes that. :)