### PR TITLE
Fix build scripts for OS X.

### DIFF
--- a/build/build_osx.sh
+++ b/build/build_osx.sh
@@ -47,7 +47,7 @@ echo build liteide tools ...
 cd $LITEIDE_ROOT
 
 
-if [ -z $GOPATH]; then
+if [ -z $GOPATH ]; then
 	export GOPATH=$PWD
 else
 	export GOPATH=$PWD:$GOPATH

--- a/build/build_osx_clang.sh
+++ b/build/build_osx_clang.sh
@@ -47,7 +47,7 @@ echo build liteide tools ...
 cd $LITEIDE_ROOT
 
 
-if [ -z $GOPATH]; then
+if [ -z $GOPATH ]; then
 	export GOPATH=$PWD
 else
 	export GOPATH=$PWD:$GOPATH


### PR DESCRIPTION
Without this fix shell checked variable "GOPATH];" in line 50, instead of "GOPATH". And broke GOPATH logic.