### PR TITLE
disable undo,redo...options after file load up

### DIFF
--- a/build/update_pkg.sh
+++ b/build/update_pkg.sh
@@ -19,12 +19,17 @@ fi
 
 echo update liteide tools ...
 cd $LITEIDE_ROOT
-export GOPATH=$PWD:$GOPATH
+
+if [ -z $GOPATH ]; then
+	export GOPATH=$PWD
+else
+	export GOPATH=$PWD:$GOPATH
+fi
 
 echo get gocode ...
-go get -v -u -ldflags "-s" "github.com/nsf/gocode"
+go get -v -ldflags "-s" "github.com/nsf/gocode"
 echo get gotools ...
-go get -v -u -ldflags "-s" "github.com/visualfc/gotools"
+go get -v -ldflags "-s" "github.com/visualfc/gotools"
 
 if [ $? -ge 1 ]; then
 	echo 'error, go install fail'

--- a/build/update_pkg.sh
+++ b/build/update_pkg.sh
@@ -27,9 +27,9 @@ else
 fi
 
 echo get gocode ...
-go get -v -ldflags "-s" "github.com/nsf/gocode"
+go get -v -u -ldflags "-s" "github.com/nsf/gocode"
 echo get gotools ...
-go get -v -ldflags "-s" "github.com/visualfc/gotools"
+go get -v -u -ldflags "-s" "github.com/visualfc/gotools"
 
 if [ $? -ge 1 ]; then
 	echo 'error, go install fail'

--- a/liteidex/src/plugins/liteeditor/liteeditor.cpp
+++ b/liteidex/src/plugins/liteeditor/liteeditor.cpp
@@ -240,15 +240,19 @@ void LiteEditor::createActions()
 
     m_undoAct = new QAction(QIcon("icon:liteeditor/images/undo.png"),tr("Undo"),this);
     actionContext->regAction(m_undoAct,"Undo",QKeySequence::Undo);
+    m_undoAct->setEnabled(false);
 
     m_redoAct = new QAction(QIcon("icon:liteeditor/images/redo.png"),tr("Redo"),this);
     actionContext->regAction(m_redoAct,"Redo","Ctrl+Shift+Z; Ctrl+Y");
-
+    m_redoAct->setEnabled(false);
+    
     m_cutAct = new QAction(QIcon("icon:liteeditor/images/cut.png"),tr("Cut"),this);
     actionContext->regAction(m_cutAct,"Cut",QKeySequence::Cut);
+    m_cutAct->setEnabled(false);
 
     m_copyAct = new QAction(QIcon("icon:liteeditor/images/copy.png"),tr("Copy"),this);
     actionContext->regAction(m_copyAct,"Copy",QKeySequence::Copy);
+    m_copyAct->setEnabled(false);
 
     m_pasteAct = new QAction(QIcon("icon:liteeditor/images/paste.png"),tr("Paste"),this);
     actionContext->regAction(m_pasteAct,"Paste",QKeySequence::Paste);


### PR DESCRIPTION
and fix

```bash
go: GOPATH entry is relative; must be absolute path: "".
```
problem  for linux users