### PR TITLE
Create fakevim plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build-liteidex-Desktop_Qt_5_7_0_GCC_64bit-Debug/*
 # C++ objects and libs
 
 *.slo

--- a/liteidex/src/3rdparty/3rdparty.pro
+++ b/liteidex/src/3rdparty/3rdparty.pro
@@ -14,4 +14,5 @@ SUBDIRS = \
     elidedlabel \
     sundown \
     cplusplus \
+    fakevim
 

--- a/liteidex/src/plugins/fakevimedit/fakevimedit.cpp
+++ b/liteidex/src/plugins/fakevimedit/fakevimedit.cpp
@@ -1,0 +1,271 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimedit.cpp
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#include "fakevim/fakevim/fakevimhandler.h"
+#include "fakevim/fakevim/fakevimactions.h"
+#include "fakevimedit.h"
+#include "fakevimedit_global.h"
+#include "qtc_editutil/uncommentselection.h"
+#include "litebuildapi/litebuildapi.h"
+#include "fileutil/fileutil.h"
+#include <QMenu>
+#include <QToolBar>
+#include <QAction>
+#include <QTextStream>
+#include <QApplication>
+#include <QToolTip>
+#include <QLabel>
+#include <QStatusBar>
+
+using namespace FakeVim::Internal;
+
+//lite_memory_check_begin
+#if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
+     #define _CRTDBG_MAP_ALLOC
+     #include <stdlib.h>
+     #include <crtdbg.h>
+     #define DEBUG_NEW new( _NORMAL_BLOCK, __FILE__, __LINE__ )
+     #define new DEBUG_NEW
+#endif
+//lite_memory_check_end
+
+FakeVimEdit::FakeVimEdit(LiteApi::IApplication *app, QObject *parent) :
+    QObject(parent),
+    m_liteApp(app),
+    m_commandLabel(NULL),
+    m_enableUseFakeVim(false)
+{
+    connect(m_liteApp->editorManager(),SIGNAL(editorCreated(LiteApi::IEditor*)),this,SLOT(editorCreated(LiteApi::IEditor*)));
+    connect(m_liteApp->editorManager(),SIGNAL(currentEditorChanged(LiteApi::IEditor*)),this,SLOT(currentEditorChanged(LiteApi::IEditor*)));
+    connect(m_liteApp->optionManager(),SIGNAL(applyOption(QString)),this,SLOT(applyOption(QString)));
+
+    this->applyOption(OPTION_FAKEVIMEDIT);
+}
+
+void FakeVimEdit::applyOption(const QString &option)
+{
+    if (option != OPTION_FAKEVIMEDIT) {
+        return;
+    }
+    m_enableUseFakeVim = m_liteApp->settings()->value(FAKEVIMEDIT_USEFAKEVIM,true).toBool();
+
+    if(m_enableUseFakeVim){
+        _enableFakeVim();
+    }else{
+        _disableFakeVim();
+    }
+}
+
+
+void FakeVimEdit::_enableFakeVim(){
+    LiteApi::IEditor *editor = m_liteApp->editorManager()->currentEditor();
+    _addFakeVimToEditor(editor);
+    _addCommandLabel();
+}
+
+void FakeVimEdit::_disableFakeVim(){
+    LiteApi::IEditor *editor = m_liteApp->editorManager()->currentEditor();
+    _removeFakeVimFromEditor(editor);
+    _removeCommandLabel();
+}
+
+QFont FakeVimEdit::commandLabelFont(){
+    QFont font;
+    font.setStyleHint(QFont::Monospace);
+    font.setBold(true);
+    return font;
+}
+
+void FakeVimEdit::_addCommandLabel(){
+    QFont font = commandLabelFont();
+
+    _removeCommandLabel();
+    m_commandLabel = new QLabel(m_liteApp->mainWindow());
+    m_commandLabel->setFont(font);
+    m_liteApp->mainWindow()->statusBar()->insertPermanentWidget(0,m_commandLabel);
+}
+
+void FakeVimEdit::_removeCommandLabel(){
+    if(!m_commandLabel){
+        return;
+    }
+    m_liteApp->mainWindow()->statusBar()->removeWidget(m_commandLabel);
+    delete m_commandLabel;
+    m_commandLabel = NULL;
+}
+
+void FakeVimEdit::_removeFakeVimFromEditor(LiteApi::IEditor *editor){
+    LiteApi::ILiteEditor  *ed = LiteApi::getLiteEditor(editor);
+
+    if (!ed) {
+        return;
+    }
+
+    QPlainTextEdit *ped = LiteApi::getPlainTextEdit(ed);
+
+    if(!ped){
+        return;
+    }
+
+    if(FakeVimHandler *fakeVimHandler = m_editorMap.value(ped)){
+        delete fakeVimHandler;
+        m_editorMap.remove(ped);
+    }
+}
+
+void FakeVimEdit::_addFakeVimToEditor(LiteApi::IEditor *editor){
+    LiteApi::ILiteEditor  *ed = LiteApi::getLiteEditor(editor);
+
+    if (!ed) {
+        return;
+    }
+
+    QPlainTextEdit *ped = LiteApi::getPlainTextEdit(ed);
+
+    if(!ped){
+        return;
+    }
+
+    if(m_editorMap.contains(ped)){
+        return;
+    }
+
+
+    FakeVimHandler *fakeVimHandler;
+
+    fakeVimHandler = new FakeVimHandler(ped,0);
+
+    connect(fakeVimHandler, SIGNAL(handleExCommandRequested(bool*,ExCommand)),
+            this, SLOT(handleExCommandRequested(bool*,ExCommand)));
+    connect(fakeVimHandler, SIGNAL(commandBufferChanged(QString,int,int,int,QObject*)),
+            this, SLOT(showMessage(QString,int)));
+
+
+    /// TODO: these options were taken from test
+    {
+        fakeVimHandler->handleCommand(("set nopasskeys"));
+        fakeVimHandler->handleCommand(("set nopasscontrolkey"));
+
+        // Set some Vim options.
+        fakeVimHandler->handleCommand(("set expandtab"));
+        fakeVimHandler->handleCommand(("set shiftwidth=8"));
+        fakeVimHandler->handleCommand(("set tabstop=16"));
+        fakeVimHandler->handleCommand(("set autoindent"));
+
+        // Try to source file "fakevimrc" from current directory.
+        fakeVimHandler->handleCommand(("source fakevimrc"));
+    }
+
+    fakeVimHandler->setCurrentFileName(ed->filePath());
+    fakeVimHandler->installEventFilter();
+    fakeVimHandler->setupWidget();
+
+    connect(ped, SIGNAL(destroyed(QObject*)), this, SLOT(plainTextEditDestroyed(QObject*)));
+
+    m_editorMap[ped] = fakeVimHandler;
+}
+
+void FakeVimEdit::plainTextEditDestroyed(QObject *obj)
+{
+    m_editorMap.remove(obj);
+}
+
+void FakeVimEdit::handleExCommandRequested(bool *b, ExCommand c)
+{
+    // Save
+    if(c.cmd == "w" ){
+        m_liteApp->editorManager()->saveEditor(m_editor);
+        *b = true;
+    }
+
+    // Save & Close
+    if(c.cmd == "x"){
+        m_liteApp->editorManager()->saveEditor(m_editor);
+        m_liteApp->editorManager()->closeEditor(m_editor);
+        *b = true;
+    }
+
+    // Close
+    if(c.cmd == "q"){
+        if(c.hasBang){
+            m_editor->reload();
+        }
+        m_liteApp->editorManager()->closeEditor(m_editor);
+        *b = true;
+    }
+}
+
+
+void FakeVimEdit::editorCreated(LiteApi::IEditor *editor)
+{
+    if (!m_enableUseFakeVim){
+        return;
+    }
+    if (!editor) {
+        return;
+    }
+    m_editor = LiteApi::getLiteEditor(editor);
+    if (m_editor) {
+        m_plainTextEdit = LiteApi::getPlainTextEdit(editor);
+    }else{
+        return;
+    }
+
+
+    if(!m_enableUseFakeVim)
+        return;
+
+    _addFakeVimToEditor(editor);
+}
+
+void FakeVimEdit::currentEditorChanged(LiteApi::IEditor *editor)
+{
+    if (!editor) {
+        return;
+    }
+    m_editor = LiteApi::getLiteEditor(editor);
+    QPlainTextEdit *ped = LiteApi::getPlainTextEdit(editor);
+
+    if (m_enableUseFakeVim){
+        if(m_editorMap.contains(ped))
+            return;
+        else
+            _addFakeVimToEditor(editor);
+    }else{
+        _removeFakeVimFromEditor(editor);
+    }
+}
+
+void FakeVimEdit::showMessage(QString contents, int cursorPos)
+{
+    if(!m_commandLabel){
+        return;
+    }
+    QString m_statusMessage = cursorPos == -1 ? contents
+        : contents.left(cursorPos) + QChar(10073) + contents.mid(cursorPos);
+
+    int slack = 14 - m_statusMessage.size();
+    QString msg = m_statusMessage + QString(slack, QLatin1Char(' '));
+
+    m_commandLabel->setText(msg);
+}

--- a/liteidex/src/plugins/fakevimedit/fakevimedit.h
+++ b/liteidex/src/plugins/fakevimedit/fakevimedit.h
@@ -1,0 +1,106 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimedit.h
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#ifndef FAKEVIMEDIT_H
+#define FAKEVIMEDIT_H
+
+#include <liteapi/liteapi.h>
+#include <liteeditorapi/liteeditorapi.h>
+#include <liteenvapi/liteenvapi.h>
+#include "processex/processex.h"
+#include "textoutput/textoutput.h"
+
+#include "fakevim/fakevim/fakevimhandler.h"
+
+using namespace FakeVim::Internal;
+
+/*
+    oracle action
+    callees	  	show possible targets of selected function call
+    callers	  	show possible callers of selected function
+    callstack 	show path from callgraph root to selected function
+    definition	show declaration of selected identifier
+    describe  	describe selected syntax: definition, methods, etc
+    freevars  	show free variables of selection
+    implements	show 'implements' relation for selected type or method
+    peers     	show send/receive corresponding to selected channel op
+    referrers 	show all refs to entity denoted by selected identifier
+    what		show basic information about the selected syntax node
+    pointsto
+    whicherrs
+*/
+
+struct OracleInfo
+{
+    QString workPath;
+    QString filePath;
+    QString fileName;
+    QString action;
+    QString output;
+    QString mode;
+    int     offset;
+    int     offset2;
+    bool    success;
+};
+
+class QLabel;
+class FakeVimEdit : public QObject
+{
+    Q_OBJECT
+public:
+    explicit FakeVimEdit(LiteApi::IApplication *app, QObject *parent = 0);
+    virtual ~FakeVimEdit(){}
+    static QFont commandLabelFont();
+
+public slots:
+    void applyOption(const QString &option);
+    void editorCreated(LiteApi::IEditor*);
+    void currentEditorChanged(LiteApi::IEditor*);
+
+protected slots:
+    void showMessage(QString contents, int);
+    void plainTextEditDestroyed(QObject *);
+
+    void handleExCommandRequested(bool*,ExCommand);
+
+private:
+    FakeVimEdit(const FakeVimEdit&);
+    FakeVimEdit& operator=(const FakeVimEdit&);
+    void _addFakeVimToEditor(LiteApi::IEditor *editor);
+    void _removeFakeVimFromEditor(LiteApi::IEditor *editor);
+    void _addCommandLabel();
+    void _removeCommandLabel();
+    void _enableFakeVim();
+    void _disableFakeVim();
+    LiteApi::IApplication *m_liteApp;
+    LiteApi::ILiteEditor  *m_editor;
+    QPlainTextEdit        *m_plainTextEdit;
+
+    bool m_enableUseFakeVim;
+
+    QLabel *m_commandLabel;
+
+    QMap<QObject *,FakeVimHandler *> m_editorMap;
+};
+
+#endif // FAKEVIMEDIT_H

--- a/liteidex/src/plugins/fakevimedit/fakevimedit.pro
+++ b/liteidex/src/plugins/fakevimedit/fakevimedit.pro
@@ -1,0 +1,23 @@
+TARGET = fakevimedit
+TEMPLATE = lib
+
+include (../../liteideplugin.pri)
+include (../../api/litefindapi/litefindapi.pri)
+include (../../api/liteeditorapi/liteeditorapi.pri)
+include (../../3rdparty/fakevim/fakevim/fakevim.pri)
+
+DEFINES += FAKEVIMEDIT_LIBRARY
+
+SOURCES += fakevimeditplugin.cpp \
+    fakevimedit.cpp \
+    fakevimeditoption.cpp \
+    fakevimeditoptionfactory.cpp
+
+HEADERS += fakevimeditplugin.h\
+        fakevimedit_global.h \
+    fakevimedit.h \
+    fakevimeditoption.h \
+    fakevimeditoptionfactory.h
+
+FORMS += \
+    fakevimeditoption.ui

--- a/liteidex/src/plugins/fakevimedit/fakevimedit_global.h
+++ b/liteidex/src/plugins/fakevimedit/fakevimedit_global.h
@@ -1,0 +1,38 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimedit_global.h
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#ifndef FAKEVIMEDIT_GLOBAL_H
+#define FAKEVIMEDIT_GLOBAL_H
+
+#include <QtCore/qglobal.h>
+
+#if defined(FAKEVIMEDIT_LIBRARY)
+#  define FAKEVIMEDITSHARED_EXPORT Q_DECL_EXPORT
+#else
+#  define FAKEVIMEDITSHARED_EXPORT Q_DECL_IMPORT
+#endif
+
+#define OPTION_FAKEVIMEDIT   "option/fakevimedit"
+#define FAKEVIMEDIT_USEFAKEVIM "fakevimedit/usefakevim"
+
+#endif // FAKEVIMEDIT_GLOBAL_H

--- a/liteidex/src/plugins/fakevimedit/fakevimeditoption.cpp
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditoption.cpp
@@ -1,0 +1,73 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimeditoption.cpp
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#include "fakevimeditoption.h"
+#include "ui_fakevimeditoption.h"
+#include "fakevimedit_global.h"
+//lite_memory_check_begin
+#if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
+     #define _CRTDBG_MAP_ALLOC
+     #include <stdlib.h>
+     #include <crtdbg.h>
+     #define DEBUG_NEW new( _NORMAL_BLOCK, __FILE__, __LINE__ )
+     #define new DEBUG_NEW
+#endif
+//lite_memory_check_end
+
+FakeVimEditOption::FakeVimEditOption(LiteApi::IApplication *app,QObject *parent) :
+    LiteApi::IOption(parent),
+    m_liteApp(app),
+    m_widget(new QWidget),
+    ui(new Ui::FakeVimEditOption)
+{
+    ui->setupUi(m_widget);
+    bool useFakeVim = m_liteApp->settings()->value(FAKEVIMEDIT_USEFAKEVIM,true).toBool();
+    ui->enableUseFakeVimCheckBox->setChecked(useFakeVim);
+}
+
+FakeVimEditOption::~FakeVimEditOption()
+{
+    delete m_widget;
+    delete ui;
+}
+
+QWidget *FakeVimEditOption::widget()
+{
+    return m_widget;
+}
+
+QString FakeVimEditOption::name() const
+{
+    return "FakeVimEdit";
+}
+
+QString FakeVimEditOption::mimeType() const
+{
+    return OPTION_FAKEVIMEDIT;
+}
+
+void FakeVimEditOption::apply()
+{
+    bool useFakeVim = ui->enableUseFakeVimCheckBox->isChecked();
+    m_liteApp->settings()->setValue(FAKEVIMEDIT_USEFAKEVIM,useFakeVim);
+}

--- a/liteidex/src/plugins/fakevimedit/fakevimeditoption.h
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditoption.h
@@ -1,0 +1,50 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimeditoption.h
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#ifndef FAKEVIMEDITOPTION_H
+#define FAKEVIMEDITOPTION_H
+
+#include "liteapi/liteapi.h"
+
+namespace Ui {
+    class FakeVimEditOption;
+}
+
+class FakeVimEditOption : public LiteApi::IOption
+{
+    Q_OBJECT
+
+public:
+    explicit FakeVimEditOption(LiteApi::IApplication *app, QObject *parent = 0);
+    ~FakeVimEditOption();
+    virtual QWidget *widget();
+    virtual QString name() const;
+    virtual QString mimeType() const;
+    virtual void apply();
+private:
+    LiteApi::IApplication   *m_liteApp;
+    QWidget           *m_widget;
+    Ui::FakeVimEditOption *ui;
+};
+
+#endif // FAKEVIMEDITOPTION_H

--- a/liteidex/src/plugins/fakevimedit/fakevimeditoption.ui
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditoption.ui
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FakeVimEditOption</class>
+ <widget class="QWidget" name="FakeVimEditOption">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>573</width>
+    <height>152</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Vim Behavior</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="enableUseFakeVimCheckBox">
+        <property name="text">
+         <string>Use FakeVim</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/liteidex/src/plugins/fakevimedit/fakevimeditoptionfactory.cpp
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditoptionfactory.cpp
@@ -1,0 +1,54 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimeditoptionfactory.cpp
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#include "fakevimeditoption.h"
+#include "fakevimeditoptionfactory.h"
+#include "fakevimedit_global.h"
+//lite_memory_check_begin
+#if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
+     #define _CRTDBG_MAP_ALLOC
+     #include <stdlib.h>
+     #include <crtdbg.h>
+     #define DEBUG_NEW new( _NORMAL_BLOCK, __FILE__, __LINE__ )
+     #define new DEBUG_NEW
+#endif
+//lite_memory_check_end
+
+FakeVimEditOptionFactory::FakeVimEditOptionFactory(LiteApi::IApplication *app, QObject *parent)
+    : LiteApi::IOptionFactory(parent),
+      m_liteApp(app)
+{
+}
+
+QStringList FakeVimEditOptionFactory::mimeTypes() const
+{
+    return QStringList() << OPTION_FAKEVIMEDIT;
+}
+
+LiteApi::IOption *FakeVimEditOptionFactory::create(const QString &mimeType)
+{
+    if (mimeType == OPTION_FAKEVIMEDIT) {
+        return new FakeVimEditOption(m_liteApp,this);
+    }
+    return 0;
+}

--- a/liteidex/src/plugins/fakevimedit/fakevimeditoptionfactory.h
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditoptionfactory.h
@@ -1,0 +1,39 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimeditoptionfactory.h
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#ifndef FAKEVIMEDITOPTIONFACTORY_H
+#define FAKEVIMEDITOPTIONFACTORY_H
+
+#include "liteapi/liteapi.h"
+
+class FakeVimEditOptionFactory : public LiteApi::IOptionFactory
+{
+public:
+    FakeVimEditOptionFactory(LiteApi::IApplication *app, QObject *parent);
+    virtual QStringList mimeTypes() const;
+    virtual LiteApi::IOption *create(const QString &mimeType);
+protected:
+    LiteApi::IApplication *m_liteApp;
+};
+
+#endif // FAKEVIMEDITOPTIONFACTORY_H

--- a/liteidex/src/plugins/fakevimedit/fakevimeditplugin.cpp
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditplugin.cpp
@@ -1,0 +1,53 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimeditplugin.cpp
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+
+#include "fakevimedit.h"
+#include "fakevimeditplugin.h"
+#include "fakevimeditoptionfactory.h"
+#include "liteeditorapi/liteeditorapi.h"
+#include <QtPlugin>
+//lite_memory_check_begin
+#if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
+     #define _CRTDBG_MAP_ALLOC
+     #include <stdlib.h>
+     #include <crtdbg.h>
+     #define DEBUG_NEW new( _NORMAL_BLOCK, __FILE__, __LINE__ )
+     #define new DEBUG_NEW
+#endif
+//lite_memory_check_end
+
+FakeVimEditPlugin::FakeVimEditPlugin()
+{
+}
+
+bool FakeVimEditPlugin::load(LiteApi::IApplication *app)
+{
+    app->optionManager()->addFactory(new FakeVimEditOptionFactory(app,this));
+    new FakeVimEdit(app,this);
+    return true;
+}
+
+#if QT_VERSION < 0x050000
+Q_EXPORT_PLUGIN2(PluginFactory,PluginFactory)
+#endif

--- a/liteidex/src/plugins/fakevimedit/fakevimeditplugin.h
+++ b/liteidex/src/plugins/fakevimedit/fakevimeditplugin.h
@@ -1,0 +1,56 @@
+/**************************************************************************
+** This file is part of LiteIDE
+**
+** Copyright (c) 2011-2016 LiteIDE Team. All rights reserved.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** In addition, as a special exception,  that plugins developed for LiteIDE,
+** are allowed to remain closed sourced and can be distributed under any license .
+** These rights are included in the file LGPL_EXCEPTION.txt in this package.
+**
+**************************************************************************/
+// Module: fakevimeditplugin.h
+// Creator: jsuppe <jon.suppe@gmail.com>
+
+#ifndef FAKEVIMEDITPLUGIN_H
+#define FAKEVIMEDITPLUGIN_H
+
+#include "liteapi/liteapi.h"
+
+class FakeVimEditPlugin : public LiteApi::IPlugin
+{
+    Q_OBJECT
+public:
+    FakeVimEditPlugin();
+    virtual bool load(LiteApi::IApplication *app);
+};
+
+class PluginFactory : public LiteApi::PluginFactoryT<FakeVimEditPlugin>
+{
+    Q_OBJECT
+    Q_INTERFACES(LiteApi::IPluginFactory)
+#if QT_VERSION >= 0x050000
+    Q_PLUGIN_METADATA(IID "liteidex.FakeVimEditPlugin")
+#endif
+public:
+    PluginFactory() {
+        m_info->setId("plugin/FakeVimEdit");
+        m_info->setVer("X29");
+        m_info->setName("FakeVimEdit");
+        m_info->setAuthor("jsuppe");
+        m_info->setInfo("Fake Vim Edit Support");
+        m_info->appendDepend("plugin/liteeditor");
+    }
+};
+
+
+#endif // FAKEVIMEDITPLUGIN_H

--- a/liteidex/src/plugins/plugins.pro
+++ b/liteidex/src/plugins/plugins.pro
@@ -25,7 +25,8 @@ SUBDIRS = \
     markdown \
     jsonedit \
     rustedit \
-    dlvdebugger 
+    dlvdebugger \
+    fakevimedit
 
 
 contains(DEFINES, LITEIDE_QTWEBKIT) {


### PR DESCRIPTION
Create FakeVim plugin. This uses the fakevim from https://github.com/hluk/FakeVim to add fakevim support to liteide. So far the only option is to enable or disable fakevim.