### PR TITLE
fix liteide_ctrlc_stub path

### DIFF
--- a/liteidex/src/utils/processex/processex.cpp
+++ b/liteidex/src/utils/processex/processex.cpp
@@ -270,7 +270,7 @@ void LiteProcess::startEx(const QString &cmd, const QString &args)
         QString stub = m_liteApp->applicationPath()+"/liteide_ctrlc_stub.exe";
         QString stubArg = cmd+" "+args;
         this->setNativeArguments(stubArg);
-        this->start(stub);
+        this->start("\""+stub+"\"");
     } else {
         this->setNativeArguments(args);
         this->start(cmd);


### PR DESCRIPTION
Debugging with dlv, liteide_ctrlc_stub will be started error as liteide install dir contains white space :) 