### PR TITLE
Update filesearchmanager highlighting bg color

### DIFF
--- a/liteidex/src/plugins/litefind/filesearchmanager.cpp
+++ b/liteidex/src/plugins/litefind/filesearchmanager.cpp
@@ -73,7 +73,7 @@ FileSearchManager::FileSearchManager(LiteApi::IApplication *app, QObject *parent
     color.textForeground = pal.color(QPalette::Text);
     color.textBackground = pal.color(QPalette::Base);
     color.highlightForeground = pal.color(QPalette::Text);
-    color.highlightBackground = QColor(255,239,11);//pal.color(QPalette::ToolTipBase);
+    color.highlightBackground = QColor(56,169,235);//pal.color(QPalette::ToolTipBase);
     QFont font = m_searchWidget->font();
     m_searchResultWidget->setTextEditorFont(font,color);
 


### PR DESCRIPTION
Color for filesearchmanager highlighting has been changed from bright
yellow to light blue for easier visibility.

I believe this was a strain to the eyes before and improves visibility.

Alternatively the yellow highlighting could be kept, but the foreground text colour should be changed to black.

Before:
[![Screenshot-2019-03-25-at-11-51-54.png](https://i.postimg.cc/D0C4xpjQ/Screenshot-2019-03-25-at-11-51-54.png)](https://postimg.cc/Wqk438Pt)

After: 
[![Screenshot-2019-03-25-at-11-51-15.png](https://i.postimg.cc/7ZHQG57p/Screenshot-2019-03-25-at-11-51-15.png)](https://postimg.cc/vcKvCH0z)