### PR TITLE
Fix fileutil.cpp builld error on Linux

### DIFF
--- a/liteidex/src/utils/fileutil/fileutil.cpp
+++ b/liteidex/src/utils/fileutil/fileutil.cpp
@@ -29,6 +29,7 @@
 #include <QDebug>
 #include <QProcess>
 #include <QDesktopServices>
+#include <QDateTime>
 #if QT_VERSION >= 0x050000
 #include <QStandardPaths>
 #endif


### PR DESCRIPTION
Compile error occurred when running build_linux_qt5.sh on Linux.
`
../../../../liteidex/src/utils/fileutil/fileutil.cpp: In member function ‘bool Trash::moveToTrash(QString)’:
../../../../liteidex/src/utils/fileutil/fileutil.cpp:685:24: error: incomplete type ‘QDateTime’ used in nested name specifier
     info += QDateTime::currentDateTime().toString("yyyy-MM-ddThh:mm:ss");
                        ^~~~~~~~~~~~~~~
Makefile:386: recipe for target '.obj/release-shared/fileutil.o' failed
`
I added a header file to solve this problem.
