### PR TITLE
Made Go playground default content to fmt compatible.

### DIFF
--- a/liteidex/src/plugins/golangplay/goplaybrowser.cpp
+++ b/liteidex/src/plugins/golangplay/goplaybrowser.cpp
@@ -52,7 +52,7 @@
 #endif
 //lite_memory_check_end
 
-QString data = "package main\n\nimport(\n\t\"fmt\"\n)\n\nfunc main(){\n\tfmt.Println(\"Hello World\")\n}";
+QString data = "package main\n\nimport (\n\t\"fmt\"\n)\n\nfunc main() {\n\tfmt.Println(\"Hello World\")\n}";
 GoplayBrowser::GoplayBrowser(LiteApi::IApplication *app, QObject *parent)
     : LiteApi::IBrowserEditor(parent),
       m_liteApp(app)


### PR DESCRIPTION
When the autocomplete added new imports, it was added in a new block.
I was thinking about adding a format button, but it was so hard to understand it.