### PR TITLE
liteidex/src/plugins/golangedit: add Find Usages and skip tests command.

### DIFF
--- a/liteidex/src/plugins/golangedit/golangedit.cpp
+++ b/liteidex/src/plugins/golangedit/golangedit.cpp
@@ -105,6 +105,9 @@ GolangEdit::GolangEdit(LiteApi::IApplication *app, QObject *parent) :
     m_findAllUseSkipGorootAct = new QAction(QString("%1 (Module/GOPATH)").arg(tr("Find Usages")),this);
     actionContext->regAction(m_findAllUseSkipGorootAct,"FindAllUsagesSkipGOROOT","CTRL+ALT+U");
 
+    m_findAllUseSkipTestsAct = new QAction(QString("%1 (Module/GOPATH) skip tests").arg(tr("Find Usages")),this);
+    actionContext->regAction(m_findAllUseSkipTestsAct,"FindAllUsagesSkipTests","");
+
     m_findAllUseWithGorootAct = new QAction(QString(tr("%1 (Module/GOPATH) with GOROOT")).arg(tr("Find Usages")),this);
     actionContext->regAction(m_findAllUseWithGorootAct,"FindAllUsagesWithGOROOT","");
 
@@ -138,6 +141,7 @@ GolangEdit::GolangEdit(LiteApi::IApplication *app, QObject *parent) :
     connect(m_renameSymbolAct,SIGNAL(triggered()),this,SLOT(editorRenameSymbol()));
     connect(m_findAllUseWithGorootAct,SIGNAL(triggered()),this,SLOT(editorFindUsagesGlobal()));
     connect(m_findAllUseSkipGorootAct,SIGNAL(triggered()),this,SLOT(editorFindUsagesSkipGoroot()));
+    connect(m_findAllUseSkipTestsAct,SIGNAL(triggered()),this,SLOT(editorFindUsagesSkipTests()));
     connect(m_renameAllSymbolWithGorootAct,SIGNAL(triggered()),this,SLOT(editorRenameSymbolGlobal()));
     connect(m_renameAllSymbolSkipGorootAct,SIGNAL(triggered()),this,SLOT(editorRenameSymbolSkipGoroot()));
     connect(m_findDefProcess,SIGNAL(started()),this,SLOT(findDefStarted()));
@@ -344,6 +348,7 @@ void GolangEdit::editorCreated(LiteApi::IEditor *editor)
         menu->addAction(m_jumpDeclAct);
         menu->addAction(m_findUseAct);
         menu->addAction(m_findAllUseSkipGorootAct);
+        menu->addAction(m_findAllUseSkipTestsAct);
         menu->addAction(m_findAllUseWithGorootAct);
         menu->addSeparator();
         QMenu *sub = menu->addMenu(tr("Refactor"));
@@ -380,6 +385,7 @@ void GolangEdit::editorCreated(LiteApi::IEditor *editor)
         menu->addAction(m_jumpDeclAct);
         menu->addAction(m_findUseAct);
         menu->addAction(m_findAllUseSkipGorootAct);
+        menu->addAction(m_findAllUseSkipTestsAct);
         menu->addAction(m_findAllUseWithGorootAct);
         menu->addSeparator();
         QMenu *sub = menu->addMenu(tr("Refactor"));
@@ -673,37 +679,43 @@ void GolangEdit::editorJumpToDecl()
 void GolangEdit::editorFindUsages()
 {
     QTextCursor cursor = m_plainTextEdit->textCursor();
-    m_fileSearch->findUsages(m_editor,cursor,false,false,false);
+    m_fileSearch->findUsages(m_editor,cursor,false,false,false,false);
 }
 
 void GolangEdit::editorFindUsagesGlobal()
 {
     QTextCursor cursor = m_plainTextEdit->textCursor();
-    m_fileSearch->findUsages(m_editor,cursor,true,false,false);
+    m_fileSearch->findUsages(m_editor,cursor,true,false,false,false);
 }
 
 void GolangEdit::editorFindUsagesSkipGoroot()
 {
     QTextCursor cursor = m_plainTextEdit->textCursor();
-    m_fileSearch->findUsages(m_editor,cursor,true,true,false);
+    m_fileSearch->findUsages(m_editor,cursor,true,true,false,false);
+}
+
+void GolangEdit::editorFindUsagesSkipTests()
+{
+    QTextCursor cursor = m_plainTextEdit->textCursor();
+    m_fileSearch->findUsages(m_editor,cursor,true,true,true,false);
 }
 
 void GolangEdit::editorRenameSymbol()
 {
     QTextCursor cursor = m_plainTextEdit->textCursor();
-    m_fileSearch->findUsages(m_editor,cursor,false,false,true);
+    m_fileSearch->findUsages(m_editor,cursor,false,false,false,true);
 }
 
 void GolangEdit::editorRenameSymbolGlobal()
 {
     QTextCursor cursor = m_plainTextEdit->textCursor();
-    m_fileSearch->findUsages(m_editor,cursor,true,false,true);
+    m_fileSearch->findUsages(m_editor,cursor,true,false,false,true);
 }
 
 void GolangEdit::editorRenameSymbolSkipGoroot()
 {
     QTextCursor cursor = m_plainTextEdit->textCursor();
-    m_fileSearch->findUsages(m_editor,cursor,true,true,true);
+    m_fileSearch->findUsages(m_editor,cursor,true,true,false,true);
 }
 
 void GolangEdit::editorComment()

--- a/liteidex/src/plugins/golangedit/golangedit.h
+++ b/liteidex/src/plugins/golangedit/golangedit.h
@@ -82,6 +82,7 @@ public slots:
     void editorFindUsages();
     void editorFindUsagesGlobal();
     void editorFindUsagesSkipGoroot();
+    void editorFindUsagesSkipTests();
     void editorRenameSymbol();
     void editorRenameSymbolGlobal();
     void editorRenameSymbolSkipGoroot();
@@ -139,6 +140,7 @@ protected:
     QAction *m_findUseAct;
     QAction *m_findAllUseWithGorootAct;
     QAction *m_findAllUseSkipGorootAct;
+	QAction *m_findAllUseSkipTestsAct;
     QAction *m_renameSymbolAct;
     QAction *m_renameAllSymbolWithGorootAct;
     QAction *m_renameAllSymbolSkipGorootAct;

--- a/liteidex/src/plugins/golangedit/golangfilesearch.cpp
+++ b/liteidex/src/plugins/golangedit/golangfilesearch.cpp
@@ -93,7 +93,7 @@ void GolangFileSearch::setSearchInfo(const QString &/*text*/, const QString &/*f
 
 }
 
-void GolangFileSearch::findUsages(LiteApi::ITextEditor *editor, QTextCursor cursor, bool global, bool skip_goroot, bool replace)
+void GolangFileSearch::findUsages(LiteApi::ITextEditor *editor, QTextCursor cursor, bool global, bool skip_goroot, bool skip_tests, bool replace)
 {
     if (!m_process->isStop()) {
         m_process->stopAndWait(100,2000);
@@ -147,6 +147,9 @@ void GolangFileSearch::findUsages(LiteApi::ITextEditor *editor, QTextCursor curs
     if (skip_goroot) {
         args << "-skip_goroot";
     }
+    if (skip_tests) {
+		args << "-skip_tests";
+	}
     args << ".";
 
     emit findStarted();

--- a/liteidex/src/plugins/golangedit/golangfilesearch.h
+++ b/liteidex/src/plugins/golangedit/golangfilesearch.h
@@ -92,7 +92,7 @@ public:
     virtual bool replaceMode() const;
     virtual bool canCancel() const { return false; }
     virtual void setSearchInfo(const QString &text, const QString &fitler, const QString &path);
-    void findUsages(LiteApi::ITextEditor *editor, QTextCursor cursor, bool global, bool skip_goroot, bool replace);
+    void findUsages(LiteApi::ITextEditor *editor, QTextCursor cursor, bool global, bool skip_goroot, bool skip_tests, bool replace);
 public slots:
     void findUsagesStarted();
     void findUsagesOutput(QByteArray,bool);


### PR DESCRIPTION
This PR adds a `Find usages (Module/GOPATH) skip tests` command.
This can be useful is you want to find out how a function call is used or a variable is initialised and want to spend time filtering out test files.
Current PR needs [this](https://github.com/visualfc/gotools/pull/13) to be merged.