### PR TITLE
Corrected Turkish Language Translation

### DIFF
--- a/liteidex/liteide_tr.ts
+++ b/liteidex/liteide_tr.ts
@@ -7,7 +7,7 @@
         <location filename="src/liteapp/aboutdialog.ui" line="20"/>
         <source>About LiteIDE</source>
         <oldsource>About Liteide</oldsource>
-        <translation>LiteIDE Hakk&#305;nda</translation>
+        <translation>LiteIDE Hakkında</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="156"/>
@@ -18,15 +18,15 @@
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="162"/>
         <source>Welcome:</source>
-        <translation>Ho&#351;geldiniz:</translation>
+        <translation>Hoşgeldiniz:</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="168"/>
         <source>Welcome to LiteIDE X! LiteIDE is a simple, open source, cross-platform IDE.</source>
         <oldsource>Welcome to LiteIDE X!
 LiteIDE is a simple, open source, cross-platform IDE.</oldsource>
-        <translation>LiteIDE X'e ho&#351;geldiniz!
-LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z bir geli&#351;tirme ortam&#305;d&#305;r.</translation>
+        <translation>LiteIDE X'e hoşgeldiniz!
+LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıdır.</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="178"/>
@@ -36,12 +36,12 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="208"/>
         <source>Name:</source>
-        <translation>Ad&#305;:</translation>
+        <translation>Adı:</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="191"/>
         <source>Author:</source>
-        <translation>Geli&#351;tirici:</translation>
+        <translation>Geliştirici:</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="222"/>
@@ -73,17 +73,17 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="297"/>
         <source>Developers</source>
-        <translation>Geli&#351;tiriciler</translation>
+        <translation>Geliştiriciler</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="400"/>
         <source>Translations</source>
-        <translation>&#199;eviriler</translation>
+        <translation>Çeviriler</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="412"/>
         <source>Chinese</source>
-        <translation>&#199;ince</translation>
+        <translation>Çince</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="426"/>
@@ -93,17 +93,17 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="440"/>
         <source>Russian</source>
-        <translation>Rus&#231;a</translation>
+        <translation>Rusça</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="454"/>
         <source>French</source>
-        <translation>Frans&#305;zca</translation>
+        <translation>Fransızca</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="468"/>
         <source>Traditional Chinese</source>
-        <translation>Geleneksel &#199;ince</translation>
+        <translation>Geleneksel Çince</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="482"/>
@@ -118,7 +118,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="537"/>
         <source>Thanks to...</source>
-        <translation>Te&#351;ekkürler...</translation>
+        <translation>Teşekkürler...</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="572"/>
@@ -133,7 +133,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/aboutdialog.cpp" line="42"/>
         <source>Based on Qt %1 (%2 bit)</source>
-        <translation>Qt sürüm %1 (%2 bit) tabanl&#305;d&#305;r</translation>
+        <translation>Qt sürüm %1 (%2 bit) tabanlıdır</translation>
     </message>
 </context>
 <context>
@@ -147,7 +147,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/liteapp/actionmanager.cpp" line="65"/>
         <source>&amp;Recent</source>
         <translatorcomment>Note to the Developer: This shoud be a sub menu of &quot;File&quot;</translatorcomment>
-        <translation>&amp;Son kullan&#305;lanlar</translation>
+        <translation>&amp;Son kullanılanlar</translation>
     </message>
     <message>
         <location filename="src/liteapp/actionmanager.cpp" line="66"/>
@@ -168,13 +168,13 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/actionmanager.cpp" line="73"/>
         <source>&amp;Help</source>
-        <translation>&amp;Yard&#305;m</translation>
+        <translation>&amp;Yardım</translation>
     </message>
     <message>
         <location filename="src/liteapp/actionmanager.cpp" line="75"/>
         <source>Standard Toolbar</source>
         <oldsource>Standard ToolBar</oldsource>
-        <translation>Standart ara&#231; &#231;ubu&#287;u</translation>
+        <translation>Standart araç çubuğu</translation>
     </message>
 </context>
 <context>
@@ -182,12 +182,12 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/plugins/golangast/astwidget.cpp" line="75"/>
         <source>Go To Definition</source>
-        <translation>Tan&#305;mlamaya Git</translation>
+        <translation>Tanımlamaya Git</translation>
     </message>
     <message>
         <location filename="src/plugins/golangast/astwidget.cpp" line="76"/>
         <source>View Import Document</source>
-        <translation>&#304;&#231;eri aktarma görünümü</translation>
+        <translation>İçeri aktarma görünümü</translation>
     </message>
 </context>
 <context>
@@ -200,7 +200,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/tooldockwidget.cpp" line="64"/>
         <source>Hide Tool Window</source>
-        <translation type="unfinished">Ara&#231; Penceresini Gizle</translation>
+        <translation type="unfinished">Araç Penceresini Gizle</translation>
     </message>
 </context>
 <context>
@@ -208,7 +208,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="72"/>
         <source>Open File</source>
-        <translation>Dosya A&#231;</translation>
+        <translation>Dosya Aç</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="73"/>
@@ -218,19 +218,19 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="74"/>
         <source>New File Wizard...</source>
-        <translation type="unfinished">Yeni Dosya Sihirbaz&#305;...</translation>
+        <translation type="unfinished">Yeni Dosya Sihirbazı...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="75"/>
         <source>Rename File...</source>
-        <translation>Dosya ad&#305;n&#305; de&#287;i&#351;tir...</translation>
+        <translation>Dosya adını değiştir...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="76"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="209"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="215"/>
         <source>Delete File</source>
-        <translation type="unfinished">Dosyay&#305; sil</translation>
+        <translation type="unfinished">Dosyayı sil</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="78"/>
@@ -240,7 +240,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="79"/>
         <source>Rename Folder...</source>
-        <translation type="unfinished">Dizini yeniden adland&#305;r...</translation>
+        <translation type="unfinished">Dizini yeniden adlandır...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="80"/>
@@ -252,12 +252,12 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="82"/>
         <source>Open Terminal Here</source>
-        <translation>Burada komut sat&#305;r&#305; a&#231;</translation>
+        <translation>Burada komut satırı aç</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="83"/>
         <source>Open Explorer Here</source>
-        <translation>Bulundu&#287;u dizini a&#231;</translation>
+        <translation>Bulunduğu dizini aç</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="85"/>
@@ -268,7 +268,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/utils/folderview/basefolderview.cpp" line="87"/>
         <source>Open Folder...</source>
         <oldsource>Add Folder...</oldsource>
-        <translation type="unfinished">Dizin A&#231;...</translation>
+        <translation type="unfinished">Dizin Aç...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="88"/>
@@ -289,7 +289,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/utils/folderview/basefolderview.cpp" line="143"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="153"/>
         <source>Create File</source>
-        <translation type="unfinished">Dosya Olu&#351;tur</translation>
+        <translation type="unfinished">Dosya Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="144"/>
@@ -299,30 +299,30 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="154"/>
         <source>Failed to create the file!</source>
-        <translation>Dosya yarat&#305;lamad&#305;!</translation>
+        <translation>Dosya yaratılamadı!</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="184"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="190"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="195"/>
         <source>Rename File</source>
-        <translation type="unfinished">Dosya &#304;smini De&#287;i&#351;tir</translation>
+        <translation type="unfinished">Dosya İsmini Değiştir</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="184"/>
         <source>New Name:</source>
-        <translation type="unfinished">Yeni &#304;sim:</translation>
+        <translation type="unfinished">Yeni İsim:</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="191"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="196"/>
         <source>Failed to rename the file!</source>
-        <translation type="unfinished">Dosya ismi de&#287;i&#351;tirilemedi!</translation>
+        <translation type="unfinished">Dosya ismi değiştirilemedi!</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="210"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bu dosyay&#305; kal&#305;c&#305; olarak silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="216"/>
@@ -333,7 +333,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/utils/folderview/basefolderview.cpp" line="234"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="237"/>
         <source>Create Folder</source>
-        <translation>Dizin Olu&#351;tur</translation>
+        <translation>Dizin Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="235"/>
@@ -343,30 +343,30 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="238"/>
         <source>Failed to create the folder!</source>
-        <translation>Dizin yarat&#305;lam&#305;yor!</translation>
+        <translation>Dizin yaratılamıyor!</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="251"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="260"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="265"/>
         <source>Rename Folder</source>
-        <translation>Dizini Yeniden Adland&#305;r</translation>
+        <translation>Dizini Yeniden Adlandır</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="251"/>
         <source>Folder Name</source>
-        <translation>Dizin Ad&#305;</translation>
+        <translation>Dizin Adı</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="261"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="266"/>
         <source>Failed to rename the folder!</source>
-        <translation>Dizin ad&#305; de&#287;i&#351;tirilemiyor!</translation>
+        <translation>Dizin adı değiştirilemiyor!</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="280"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini i&#231;indeki tüm alt dizin ve dosyalarla birlikte silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="287"/>
@@ -380,7 +380,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="14"/>
         <source>Build Configuration</source>
         <oldsource>Build Config Dialog</oldsource>
-        <translation>Build Ayarlar&#305;</translation>
+        <translation>Build Ayarları</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="26"/>
@@ -416,7 +416,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="94"/>
         <source>Create Folder</source>
-        <translation>Dizin Olu&#351;tur</translation>
+        <translation>Dizin Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="96"/>
@@ -426,17 +426,17 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="98"/>
         <source>Dir Name:</source>
-        <translation>Dizin Ad&#305;:</translation>
+        <translation>Dizin Adı:</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="106"/>
         <source>Create</source>
-        <translation>Olu&#351;tur</translation>
+        <translation>Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="107"/>
         <source>Cancel</source>
-        <translation>Vazge&#231;</translation>
+        <translation>Vazgeç</translation>
     </message>
 </context>
 <context>
@@ -445,7 +445,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/utils/folderview/folderdialog.cpp" line="44"/>
         <source>Create File</source>
         <oldsource>Create File Dialog</oldsource>
-        <translation>Dosya Olu&#351;tur</translation>
+        <translation>Dosya Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="46"/>
@@ -455,22 +455,22 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="48"/>
         <source>File Name:</source>
-        <translation>Dosya Ad&#305;:</translation>
+        <translation>Dosya Adı:</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="56"/>
         <source>Create</source>
-        <translation>Olu&#351;tur</translation>
+        <translation>Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="57"/>
         <source>Create and Edit</source>
-        <translation>Olu&#351;utur ve Düzenle</translation>
+        <translation>Oluşutur ve Düzenle</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="58"/>
         <source>Cancel</source>
-        <translation>Vazge&#231;</translation>
+        <translation>Vazgeç</translation>
     </message>
 </context>
 <context>
@@ -479,23 +479,23 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="80"/>
         <source>Async Record</source>
         <oldsource>AsyncRecord</oldsource>
-        <translation>Asenkron Kay&#305;t</translation>
+        <translation>Asenkron Kayıt</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="81"/>
         <source>Variables</source>
-        <translation>De&#287;i&#351;kenler</translation>
+        <translation>Değişkenler</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="82"/>
         <source>Watch</source>
-        <translation>&#304;zle</translation>
+        <translation>İzle</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="83"/>
         <source>Call Stack</source>
         <oldsource>CallStack</oldsource>
-        <translation>&#199;a&#287;r&#305; Y&#305;&#287;&#305;n&#305;</translation>
+        <translation>Çağrı Yığını</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="84"/>
@@ -512,23 +512,23 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="94"/>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="259"/>
         <source>Add Global Watch</source>
-        <translation>Genel &#304;zlemeye Al</translation>
+        <translation>Genel İzlemeye Al</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="95"/>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="271"/>
         <source>Add Local Watch</source>
-        <translation>Lokal &#304;zlemeye Al</translation>
+        <translation>Lokal İzlemeye Al</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="96"/>
         <source>Remove Watch</source>
-        <translation>&#304;zlemeden Kald&#305;r</translation>
+        <translation>İzlemeden Kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="97"/>
         <source>Remove All Watches</source>
-        <translation>Tüm &#304;zlemeleri Kald&#305;r</translation>
+        <translation>Tüm İzlemeleri Kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/debugwidget.cpp" line="259"/>
@@ -552,7 +552,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="68"/>
         <source>Forward</source>
-        <translation>&#304;leri</translation>
+        <translation>İleri</translation>
     </message>
     <message>
         <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="69"/>
@@ -562,17 +562,17 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="75"/>
         <source>Increase Font Size</source>
-        <translation>Yaz&#305;tipini Büyüt</translation>
+        <translation>Yazıtipini Büyüt</translation>
     </message>
     <message>
         <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="78"/>
         <source>Decrease Font Size</source>
-        <translation>Yaz&#305;tipini Kü&#231;ült</translation>
+        <translation>Yazıtipini Küçült</translation>
     </message>
     <message>
         <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="81"/>
         <source>Reset Font Size</source>
-        <translation>Yaz&#305;tipi Boyutunu S&#305;f&#305;rla</translation>
+        <translation>Yazıtipi Boyutunu Sıfırla</translation>
     </message>
 </context>
 <context>
@@ -586,7 +586,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/liteapp/editormanager.cpp" line="125"/>
         <source>Move to New Window</source>
         <oldsource>Move To New Window</oldsource>
-        <translation>Yeni Pencereye Ta&#351;&#305;</translation>
+        <translation>Yeni Pencereye Taşı</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="171"/>
@@ -598,13 +598,13 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/liteapp/editormanager.cpp" line="185"/>
         <source>Navigate Forward</source>
         <oldsource>GoForward</oldsource>
-        <translation>&#304;leri Git</translation>
+        <translation>İleri Git</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="116"/>
         <source>Close Others</source>
         <oldsource>Close Others Tabs</oldsource>
-        <translation>Di&#287;erlerini Kapat</translation>
+        <translation>Diğerlerini Kapat</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="117"/>
@@ -620,19 +620,19 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="119"/>
         <source>Close Right Tabs</source>
-        <translation>Sa&#287;daki Sekmeleri Kapat</translation>
+        <translation>Sağdaki Sekmeleri Kapat</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="120"/>
         <source>Close Files in Same Folder</source>
         <oldsource>Close Same Folder Files</oldsource>
-        <translation>Ayn&#305; Dizindeki Dosyalar&#305; Kapat</translation>
+        <translation>Aynı Dizindeki Dosyaları Kapat</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="121"/>
         <source>Close Files in Other Folders</source>
         <oldsource>Close Other Folder Files</oldsource>
-        <translation>Di&#287;er Dizinlerdeki Dosyalar&#305; Kapat</translation>
+        <translation>Diğer Dizinlerdeki Dosyaları Kapat</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="122"/>
@@ -653,13 +653,13 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="364"/>
         <source>Save changes to %1?</source>
-        <translation>De&#287;i&#351;ikler %1 i&#231;ine kaydedilsin mi?</translation>
+        <translation>Değişikler %1 içine kaydedilsin mi?</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="365"/>
         <source>Unsaved Modifications</source>
         <oldsource>Save Modify</oldsource>
-        <translation>Kaydedilmemi&#351; De&#287;i&#351;iklikler</translation>
+        <translation>Kaydedilmemiş Değişiklikler</translation>
     </message>
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="447"/>
@@ -669,7 +669,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/liteapp/editormanager.cpp" line="449"/>
         <source>Save As</source>
-        <translation>Farkl&#305; Kaydet</translation>
+        <translation>Farklı Kaydet</translation>
     </message>
 </context>
 <context>
@@ -678,25 +678,25 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/plugins/liteenv/envmanager.cpp" line="358"/>
         <source>Environment Toolbar</source>
         <oldsource>Environment ToolBar</oldsource>
-        <translation>&#199;Al&#305;&#351;ma ortam&#305; Ara&#231; &#199;ubu&#287;u</translation>
+        <translation>ÇAlışma ortamı Araç Çubuğu</translation>
     </message>
     <message>
         <location filename="src/plugins/liteenv/envmanager.cpp" line="365"/>
         <source>Switching current environment</source>
         <oldsource>Switch Current Environment</oldsource>
-        <translation>&#199;al&#305;&#351;ma ortam&#305; de&#287;i&#351;tiriliyor</translation>
+        <translation>Çalışma ortamı değiştiriliyor</translation>
     </message>
     <message>
         <location filename="src/plugins/liteenv/envmanager.cpp" line="368"/>
         <source>Edit current environment</source>
         <oldsource>Edit Current Environment</oldsource>
-        <translation>&#199;al&#305;&#351;ma ortam&#305;n&#305; düzenle</translation>
+        <translation>Çalışma ortamını düzenle</translation>
     </message>
     <message>
         <location filename="src/plugins/liteenv/envmanager.cpp" line="369"/>
         <source>Reload current environment</source>
         <oldsource>Reload Current Environment</oldsource>
-        <translation>&#199;al&#305;&#351;ma ortam&#305;n&#305; yenile</translation>
+        <translation>Çalışma ortamını yenile</translation>
     </message>
 </context>
 <context>
@@ -704,22 +704,22 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation>D&#305;&#351;a Aktar</translation>
+        <translation>Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="22"/>
         <source>Name:</source>
-        <translation>&#304;sim:</translation>
+        <translation>İsim:</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="49"/>
         <source>Export</source>
-        <translation>D&#305;&#351;a Aktar</translation>
+        <translation>Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="56"/>
         <source>ExportAndView</source>
-        <translation>D&#305;&#351;a Aktar ve Görüntüle</translation>
+        <translation>Dışa Aktar ve Görüntüle</translation>
     </message>
 </context>
 <context>
@@ -727,17 +727,17 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/plugins/litetty/fifotty.cpp" line="86"/>
         <source>Cannot create temporary file: %1</source>
-        <translation>Ge&#231;ici dosya yarat&#305;lam&#305;yor: %1</translation>
+        <translation>Geçici dosya yaratılamıyor: %1</translation>
     </message>
     <message>
         <location filename="src/plugins/litetty/fifotty.cpp" line="97"/>
         <source>Cannot create FiFo %1: %2</source>
-        <translation>FiFo %1 yarat&#305;lam&#305;yor: %2</translation>
+        <translation>FiFo %1 yaratılamıyor: %2</translation>
     </message>
     <message>
         <location filename="src/plugins/litetty/fifotty.cpp" line="104"/>
         <source>Cannot open FiFo %1: %2</source>
-        <translation>FiFo %1 a&#231;&#305;lam&#305;yor: %2</translation>
+        <translation>FiFo %1 açılamıyor: %2</translation>
     </message>
 </context>
 <context>
@@ -750,18 +750,18 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="93"/>
         <source>Show Hidden Files</source>
-        <translation>Gizli Dosyalar&#305; Göster</translation>
+        <translation>Gizli Dosyaları Göster</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="144"/>
         <source>Set As Root Folder</source>
         <oldsource>Set Folder To Root</oldsource>
-        <translation>Kök Dizin Olarak &#304;&#351;aretle</translation>
+        <translation>Kök Dizin Olarak İşaretle</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="100"/>
         <source>Execute File</source>
-        <translation>Dosyay&#305; &#199;al&#305;&#351;t&#305;r</translation>
+        <translation>Dosyayı Çalıştır</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="91"/>
@@ -771,7 +771,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="145"/>
         <source>Open Folder in New Window</source>
-        <translation>Dizini Yeni Pencerede A&#231;</translation>
+        <translation>Dizini Yeni Pencerede Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="146"/>
@@ -786,7 +786,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="119"/>
         <source>Open Parent</source>
         <oldsource>Open to Parent</oldsource>
-        <translation>Üst Dizini A&#231;</translation>
+        <translation>Üst Dizini Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowser.cpp" line="154"/>
@@ -809,7 +809,7 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
     <message>
         <location filename="src/plugins/filebrowser/filebrowseroption.ui" line="20"/>
         <source>Terminal</source>
-        <translation>Komut Sat&#305;r&#305;</translation>
+        <translation>Komut Satırı</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowseroption.ui" line="26"/>
@@ -842,18 +842,18 @@ LiteIDE sade, a&#231;&#305;k kaynakl&#305; ve platform ba&#287;&#305;ms&#305;z b
 Do you want to open it now?</source>
         <oldsource>Project &apos;%1&apos; is created.
 Do you want to load?</oldsource>
-        <translation>&apos;%1&apos; projesi yarat&#305;ld&#305;.
+        <translation>&apos;%1&apos; projesi yaratıldı.
 Yüklemek ister misin?</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="301"/>
         <source>Open Project or File</source>
-        <translation>Dosya veya Proje A&#231;</translation>
+        <translation>Dosya veya Proje Aç</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="79"/>
         <source>Show Hidden Files</source>
-        <translation>Gizli Dosyalar&#305; Göster</translation>
+        <translation>Gizli Dosyaları Göster</translation>
     </message>
     <message>
         <source>Config</source>
@@ -868,21 +868,21 @@ Yüklemek ister misin?</translation>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="103"/>
         <source>Clear History</source>
-        <translation>Ge&#231;mi&#351;i Sil</translation>
+        <translation>Geçmişi Sil</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="179"/>
         <location filename="src/liteapp/filemanager.cpp" line="200"/>
         <location filename="src/liteapp/filemanager.cpp" line="221"/>
         <source>All Support Files (%1)</source>
-        <translation>Tüm Yard&#305;m Dosyalar&#305; (%1)</translation>
+        <translation>Tüm Yardım Dosyaları (%1)</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="314"/>
         <location filename="src/liteapp/filemanager.cpp" line="332"/>
         <source>Select a folder:</source>
         <oldsource>Open Folder</oldsource>
-        <translation>Bir dizin se&#231;:</translation>
+        <translation>Bir dizin seç:</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="529"/>
@@ -934,11 +934,11 @@ but you have unsaved modifications in your LiteIDE editor.
 Do you want to reload the file from disk?
 Answering &quot;Yes&quot; will discard your unsaved changes.</source>
         <translation>%1
-Bu dosya sabit diskte de&#287;i&#351;ikli&#287;e u&#287;rad&#305; ancak,
-LiteIDE editöründe henüz kaydedilmemi&#351; de&#287;i&#351;iklikleriniz var.
+Bu dosya sabit diskte değişikliğe uğradı ancak,
+LiteIDE editöründe henüz kaydedilmemiş değişiklikleriniz var.
 
-Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?
-&quot;Evet&quot; demeniz halinde kaydedilmemi&#351; de&#287;i&#351;iklikleriniz gözard&#305; edilecek.
+Dosya içeriği diskten okunarak güncellensin mi?
+&quot;Evet&quot; demeniz halinde kaydedilmemiş değişiklikleriniz gözardı edilecek.
         </translation>
     </message>
     <message>
@@ -948,14 +948,14 @@ This file has been modified on the drive.
 
 Do you want to reload the file from disk?</source>
         <translation>%1
-Bu dosya sabit diskte de&#287;i&#351;ikli&#287;e u&#287;rad&#305;.
+Bu dosya sabit diskte değişikliğe uğradı.
 
-Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
+Dosya içeriği diskten okunarak güncellensin mi?</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="351"/>
         <source>Open Files</source>
-        <translation>Dosyalar&#305; A&#231;</translation>
+        <translation>Dosyaları Aç</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="86"/>
@@ -970,7 +970,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="364"/>
         <source>Open Project</source>
-        <translation>Proje A&#231;</translation>
+        <translation>Proje Aç</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="789"/>
@@ -987,12 +987,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/litefind/filesearch.cpp" line="203"/>
         <source>Match whole word</source>
         <oldsource>Match word</oldsource>
-        <translation>Tüm kelimeleri e&#351;le&#351;tir</translation>
+        <translation>Tüm kelimeleri eşleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="204"/>
         <source>Match case</source>
-        <translation>Büyük/kü&#231;ük harf duyarl&#305;</translation>
+        <translation>Büyük/küçük harf duyarlı</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="205"/>
@@ -1008,7 +1008,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="226"/>
         <source>Search for:</source>
-        <translation>&#350;unu ara:</translation>
+        <translation>Şunu ara:</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="228"/>
@@ -1025,7 +1025,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/litefind/filesearch.cpp" line="235"/>
         <source>Use Current</source>
         <oldsource>Current</oldsource>
-        <translation>Varsay&#305;lan&#305; Kullan</translation>
+        <translation>Varsayılanı Kullan</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="252"/>
@@ -1045,7 +1045,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="216"/>
         <source>Cancel</source>
-        <translation>Vazge&#231;</translation>
+        <translation>Vazgeç</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="257"/>
@@ -1055,7 +1055,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/filesearch.cpp" line="444"/>
         <source>Open Directory</source>
-        <translation>Dizini A&#231;</translation>
+        <translation>Dizini Aç</translation>
     </message>
 </context>
 <context>
@@ -1063,13 +1063,13 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="50"/>
         <source>Search Item:</source>
-        <translation>Ö&#287;e Ara:</translation>
+        <translation>Öğe Ara:</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="69"/>
         <source>Only golang file changes can be revert!</source>
         <oldsource>This file change cannot be undone!</oldsource>
-        <translation>Sadece golang dosya de&#287;i&#351;iklikleri geri al&#305;nabilir!</translation>
+        <translation>Sadece golang dosya değişiklikleri geri alınabilir!</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="83"/>
@@ -1079,12 +1079,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="86"/>
         <source>Search Result</source>
-        <translation>Arama Sonu&#231;lar&#305;</translation>
+        <translation>Arama Sonuçları</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="233"/>
         <source>The following files have no write permissions. Do you want to change the permissions?</source>
-        <translation>A&#351;a&#287;&#305;daki dosyalara yazma izni yok? Yazma izni i&#231;in yetki de&#287;i&#351;ikli&#287;i yap&#305;ls&#305;n m&#305;?</translation>
+        <translation>Aşağıdaki dosyalara yazma izni yok? Yazma izni için yetki değişikliği yapılsın mı?</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="236"/>
@@ -1098,7 +1098,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="94"/>
         <source>Open File</source>
         <oldsource>Open Editor</oldsource>
-        <translation>Dosya A&#231;</translation>
+        <translation>Dosya Aç</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="95"/>
@@ -1110,14 +1110,14 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="96"/>
         <source>New File Wizard...</source>
         <oldsource>New File Wizard</oldsource>
-        <translation>Yeni Dosya Sihirbaz&#305;...</translation>
+        <translation>Yeni Dosya Sihirbazı...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="320"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="326"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="331"/>
         <source>Rename File</source>
-        <translation>Dosya Ad&#305;n&#305; De&#287;i&#351;tir</translation>
+        <translation>Dosya Adını Değiştir</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="98"/>
@@ -1125,7 +1125,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="350"/>
         <source>Delete File</source>
         <oldsource>Remove File</oldsource>
-        <translation>Dosyay&#305; Sil</translation>
+        <translation>Dosyayı Sil</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="100"/>
@@ -1136,14 +1136,14 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="346"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bo dosyay&#305; kal&#305;c&#305; olarak silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bo dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="386"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="395"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="400"/>
         <source>Rename Folder</source>
-        <translation>Dizini Yeniden Adland&#305;r</translation>
+        <translation>Dizini Yeniden Adlandır</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="102"/>
@@ -1156,22 +1156,22 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="97"/>
         <source>Rename File...</source>
-        <translation>Dosyay&#305; Yeniden Adland&#305;r...</translation>
+        <translation>Dosyayı Yeniden Adlandır...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="101"/>
         <source>Rename Folder...</source>
-        <translation>Dizini Yeniden Adland&#305;r...</translation>
+        <translation>Dizini Yeniden Adlandır...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="104"/>
         <source>Open Terminal Here</source>
-        <translation>Burada Komut Sat&#305;r&#305;n&#305; A&#231;</translation>
+        <translation>Burada Komut Satırını Aç</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="105"/>
         <source>Open Explorer Here</source>
-        <translation>Buray&#305; Dizinde Göster</translation>
+        <translation>Burayı Dizinde Göster</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="107"/>
@@ -1202,7 +1202,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="279"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="289"/>
         <source>Create File</source>
-        <translation>Dosya Olu&#351;tur</translation>
+        <translation>Dosya Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="280"/>
@@ -1213,23 +1213,23 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="290"/>
         <source>Failed to create the file!</source>
-        <translation>Dosya yarat&#305;lam&#305;yor!</translation>
+        <translation>Dosya yaratılamıyor!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="320"/>
         <source>New Name:</source>
-        <translation>Yeni &#304;sim:</translation>
+        <translation>Yeni İsim:</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="327"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="332"/>
         <source>Failed to rename the file!</source>
-        <translation>Dosya &#304;smi De&#287;i&#351;tirilemiyor!</translation>
+        <translation>Dosya İsmi Değiştirilemiyor!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="415"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini i&#231;indeki tüm alt dizin ve dosyalarla birlikte silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="351"/>
@@ -1241,7 +1241,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="369"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="372"/>
         <source>Create Folder</source>
-        <translation>Dizin Olu&#351;tur</translation>
+        <translation>Dizin Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="370"/>
@@ -1252,18 +1252,18 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="373"/>
         <source>Failed to create the folder!</source>
-        <translation>Dizin olu&#351;turulam&#305;yor!</translation>
+        <translation>Dizin oluşturulamıyor!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="386"/>
         <source>Folder Name</source>
-        <translation>Dizin Ad&#305;</translation>
+        <translation>Dizin Adı</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="396"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="401"/>
         <source>Failed to rename the folder!</source>
-        <translation>Dizin ad&#305; de&#287;i&#351;tirilemiyor!</translation>
+        <translation>Dizin adı değiştirilemiyor!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="422"/>
@@ -1282,12 +1282,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="163"/>
         <source>Cancel</source>
-        <translation>Vazge&#231;</translation>
+        <translation>Vazgeç</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="167"/>
         <source>Repeat the search with same parameters</source>
-        <translation>Aramay&#305; ayn&#305; parametrelerle tekrar yap</translation>
+        <translation>Aramayı aynı parametrelerle tekrar yap</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="168"/>
@@ -1297,40 +1297,40 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="174"/>
         <source>Set show replace mode ui</source>
-        <translation>De&#287;i&#351;iklik yapma modunu göster</translation>
+        <translation>Değişiklik yapma modunu göster</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="175"/>
         <source>Show Replace</source>
-        <translation>De&#287;i&#351;tir</translation>
+        <translation>Değiştir</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="180"/>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="437"/>
         <source>Replace with:</source>
-        <translation>&#350;ununla de&#287;i&#351;tir:</translation>
+        <translation>Şununla değiştir:</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="186"/>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="438"/>
         <source>Replace all occurrences</source>
-        <translation>Tümünü de&#287;i&#351;tir</translation>
+        <translation>Tümünü değiştir</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="187"/>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="439"/>
         <source>Replace</source>
-        <translation>De&#287;i&#351;tir</translation>
+        <translation>Değiştir</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="191"/>
         <source>Preserve case</source>
-        <translation>BÜYÜK/Kü&#231;ük harfleri koru</translation>
+        <translation>BÜYÜK/Küçük harfleri koru</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="304"/>
         <source>Revert with:</source>
-        <translation>&#350;ununla geri al:</translation>
+        <translation>Şununla geri al:</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="305"/>
@@ -1345,27 +1345,27 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message numerus="yes">
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="575"/>
         <source>%n matches replaced.</source>
-        <translation>%n e&#351;le&#351;me de&#287;i&#351;tirildi</translation>
+        <translation>%n eşleşme değiştirildi</translation>
     </message>
     <message numerus="yes">
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="577"/>
         <source>searching... %n matches found.</source>
-        <translation>aran&#305;yor... %n e&#351;le&#351;me bulundu.</translation>
+        <translation>aranıyor... %n eşleşme bulundu.</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="583"/>
         <source>searching ...</source>
-        <translation>aran&#305;yor ...</translation>
+        <translation>aranıyor ...</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="589"/>
         <source>No matches found.</source>
-        <translation>Hi&#231; sonu&#231; bulunamad&#305;.</translation>
+        <translation>Hiç sonuç bulunamadı.</translation>
     </message>
     <message numerus="yes">
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="591"/>
         <source>%n matches found.</source>
-        <translation>%n sonu&#231; found</translation>
+        <translation>%n sonuç found</translation>
     </message>
 </context>
 <context>
@@ -1378,7 +1378,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/findapiwidget.h" line="70"/>
         <source>Stop Search</source>
-        <translation>Aramay&#305; Durdur</translation>
+        <translation>Aramayı Durdur</translation>
     </message>
 </context>
 <context>
@@ -1397,7 +1397,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="313"/>
         <source>Rebuild database</source>
-        <translation>Veritaban&#305;n&#305; yeniden indeksle</translation>
+        <translation>Veritabanını yeniden indeksle</translation>
     </message>
 </context>
 <context>
@@ -1440,7 +1440,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="130"/>
         <source>Find struct</source>
-        <translation>Yap&#305; bul (struct)</translation>
+        <translation>Yapı bul (struct)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="132"/>
@@ -1450,27 +1450,27 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="134"/>
         <source>Find var</source>
-        <translation>De&#287;i&#351;ken bul (var)</translation>
+        <translation>Değişken bul (var)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="136"/>
         <source>Use Regexp</source>
-        <translation>Düzenli &#304;fade Kullan</translation>
+        <translation>Düzenli İfade Kullan</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="138"/>
         <source>Match Case</source>
-        <translation>BÜYÜK/Kü&#231;ük Harfe Duyarl&#305;</translation>
+        <translation>BÜYÜK/Küçük Harfe Duyarlı</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="140"/>
         <source>Match Word</source>
-        <translation>Kelime E&#351;le&#351;tir</translation>
+        <translation>Kelime Eşleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="167"/>
         <source>Help</source>
-        <translation>Yard&#305;m</translation>
+        <translation>Yardım</translation>
     </message>
 </context>
 <context>
@@ -1478,7 +1478,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="63"/>
         <source>Match case</source>
-        <translation>BÜYÜK/Kü&#231;ük Harfe Duyarl&#305;</translation>
+        <translation>BÜYÜK/Küçük Harfe Duyarlı</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="64"/>
@@ -1488,7 +1488,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="65"/>
         <source>Wrap around</source>
-        <translation>Etraf&#305;nda Ara</translation>
+        <translation>Etrafında Ara</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="56"/>
@@ -1504,29 +1504,29 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="58"/>
         <source>Replace With:</source>
-        <translation>&#350;ununla de&#287;i&#351;tir:</translation>
+        <translation>Şununla değiştir:</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="59"/>
         <source>Replace</source>
-        <translation>De&#287;i&#351;tir</translation>
+        <translation>Değiştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="60"/>
         <source>Replace All</source>
-        <translation>Tümünü De&#287;i&#351;tir</translation>
+        <translation>Tümünü Değiştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="62"/>
         <source>Match whole word only</source>
-        <translation>Tüm cümleyi e&#351;le&#351;tir</translation>
+        <translation>Tüm cümleyi eşleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="72"/>
         <location filename="src/plugins/litefind/findeditor.cpp" line="238"/>
         <location filename="src/plugins/litefind/findeditor.cpp" line="441"/>
         <source>Ready</source>
-        <translation>Haz&#305;r</translation>
+        <translation>Hazır</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="81"/>
@@ -1536,7 +1536,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="99"/>
         <source>Find What:</source>
-        <translation>&#350;unu Bul:</translation>
+        <translation>Şunu Bul:</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="110"/>
@@ -1548,7 +1548,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/litefind/findeditor.cpp" line="209"/>
         <location filename="src/plugins/litefind/findeditor.cpp" line="364"/>
         <source>Not found</source>
-        <translation>Bulunamad&#305;</translation>
+        <translation>Bulunamadı</translation>
     </message>
 </context>
 <context>
@@ -1557,12 +1557,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/folderview/folderlistview.cpp" line="268"/>
         <location filename="src/utils/folderview/folderlistview.cpp" line="278"/>
         <source>Delete File</source>
-        <translation>Dosyay&#305; Sil</translation>
+        <translation>Dosyayı Sil</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderlistview.cpp" line="269"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bu dosyay&#305; kal&#305;c&#305; olarak silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderlistview.cpp" line="279"/>
@@ -1578,7 +1578,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/utils/folderview/folderlistview.cpp" line="292"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini i&#231;indeki tüm alt dizin ve dosyalarla birlikte silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderlistview.cpp" line="302"/>
@@ -1592,12 +1592,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/folderview/folderview.cpp" line="148"/>
         <location filename="src/utils/folderview/folderview.cpp" line="158"/>
         <source>Delete File</source>
-        <translation>Dosyay&#305; Sil</translation>
+        <translation>Dosyayı Sil</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderview.cpp" line="149"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bu dosyay&#305; kal&#305;c&#305; olarak silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderview.cpp" line="159"/>
@@ -1613,7 +1613,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/utils/folderview/folderview.cpp" line="172"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini i&#231;indeki tüm alt dizin ve dosyalarla birlikte silmek istedi&#287;inize emin misiniz?</translation>
+        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderview.cpp" line="182"/>
@@ -1631,7 +1631,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/gdbdebugger/gdbdebuggeroption.ui" line="20"/>
         <source>Enable --tty for program being debugged.</source>
-        <translation>Hata ay&#305;klarken --tty a&#231;&#305;k kals&#305;n.</translation>
+        <translation>Hata ayıklarken --tty açık kalsın.</translation>
     </message>
 </context>
 <context>
@@ -1639,12 +1639,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangast/golangast.cpp" line="58"/>
         <source>No outline available</source>
-        <translation>Hi&#231; genel görünüm yok</translation>
+        <translation>Hiç genel görünüm yok</translation>
     </message>
     <message>
         <location filename="src/plugins/golangast/golangast.cpp" line="72"/>
         <source>Class View</source>
-        <translation>S&#305;n&#305;f Görünümü</translation>
+        <translation>Sınıf Görünümü</translation>
     </message>
     <message>
         <location filename="src/plugins/golangast/golangast.cpp" line="73"/>
@@ -1669,12 +1669,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
         <source>Auto update depends package when it&apos;s source changed.</source>
         <oldsource>Auto update depends package when its source is changed.</oldsource>
-        <translation>Kullan&#305;lan paketlerin kaynak kodu de&#287;i&#351;ti&#287;inde otomatik güncelle</translation>
+        <translation>Kullanılan paketlerin kaynak kodu değiştiğinde otomatik güncelle</translation>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="26"/>
         <source>Close gocode when exiting</source>
-        <translation>&#199;&#305;karken go kodunu kapat</translation>
+        <translation>Çıkarken go kodunu kapat</translation>
     </message>
 </context>
 <context>
@@ -1715,13 +1715,13 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/golangdocoption.ui" line="26"/>
         <source>Use default context (fast)</source>
-        <translation>Varsay&#305;lan context'i kullan (h&#305;zl&#305;)</translation>
+        <translation>Varsayılan context'i kullan (hızlı)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/golangdocoption.ui" line="33"/>
         <source>Only load standard API documentation</source>
         <oldsource>Only load standard api</oldsource>
-        <translation>Sadece standart API dökümanlar&#305;n&#305; yükle</translation>
+        <translation>Sadece standart API dökümanlarını yükle</translation>
     </message>
 </context>
 <context>
@@ -1729,7 +1729,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="73"/>
         <source>View import package use godoc</source>
-        <translation>Paket &#231;a&#287;&#305;rma kullan&#305;m&#305;n&#305; göster</translation>
+        <translation>Paket çağırma kullanımını göster</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="76"/>
@@ -1739,19 +1739,19 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="79"/>
         <source>Jump to Declaration</source>
-        <translation>Tan&#305;mlanan yere git</translation>
+        <translation>Tanımlanan yere git</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="82"/>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="88"/>
         <source>Find Usages</source>
-        <translation>Kullan&#305;lan Yerleri Bul</translation>
+        <translation>Kullanılan Yerleri Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="85"/>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="91"/>
         <source>Rename Symbol Under Cursor</source>
-        <translation>&#304;&#351;aret&#231;i alt&#305;ndaki sembolü yeniden adland&#305;r</translation>
+        <translation>İşaretçi altındaki sembolü yeniden adlandır</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="136"/>
@@ -1767,27 +1767,27 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="142"/>
         <source>Callees</source>
-        <translation>&#199;a&#287;r&#305;lanlar</translation>
+        <translation>Çağrılanlar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="146"/>
         <source>Callers</source>
-        <translation>&#199;a&#287;&#305;ranlar</translation>
+        <translation>Çağıranlar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="150"/>
         <source>Callstack</source>
-        <translation>&#199;a&#287;r&#305; y&#305;&#287;&#305;n&#305;</translation>
+        <translation>Çağrı yığını</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="154"/>
         <source>Definition</source>
-        <translation>Tan&#305;m</translation>
+        <translation>Tanım</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="158"/>
         <source>Describe</source>
-        <translation>A&#231;&#305;klama</translation>
+        <translation>Açıklama</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="162"/>
@@ -1802,7 +1802,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="170"/>
         <source>Peers</source>
-        <translation>Ba&#287;lar</translation>
+        <translation>Bağlar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="174"/>
@@ -1812,7 +1812,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="178"/>
         <source>Pointsto</source>
-        <translation>&#304;&#351;aret edenler</translation>
+        <translation>İşaret edenler</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangedit.cpp" line="182"/>
@@ -1841,12 +1841,12 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangeditoption.ui" line="26"/>
         <source>Enable view expression infomation on mouse</source>
-        <translation>Fare üzerine geldi&#287;inde sözdizimi bilgisi göster</translation>
+        <translation>Fare üzerine geldiğinde sözdizimi bilgisi göster</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangeditoption.ui" line="33"/>
         <source>Enable mouse navigation</source>
-        <translation>Fare ile navigasyonu etkinle&#351;tir</translation>
+        <translation>Fare ile navigasyonu etkinleştir</translation>
     </message>
 </context>
 <context>
@@ -1854,7 +1854,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangedit/golangfilesearch.cpp" line="54"/>
         <source>Golang Find Usages</source>
-        <translation>Golang Kullan&#305;lan Yerleri Bul</translation>
+        <translation>Golang Kullanılan Yerleri Bul</translation>
     </message>
 </context>
 <context>
@@ -1868,32 +1868,32 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="20"/>
         <source>Format Options</source>
         <oldsource>Golang Format</oldsource>
-        <translation>Format Ayarlar&#305;</translation>
+        <translation>Format Ayarları</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="26"/>
         <source>Goimports updates your Go import lines, adding missing ones and removing unreferenced ones.</source>
-        <translation>Goimports, import sat&#305;rlar&#305;n&#305; günceller, eksik olanlar&#305; ekler ve kullan&#305;lmayanlar&#305; kald&#305;r&#305;r.</translation>
+        <translation>Goimports, import satırlarını günceller, eksik olanları ekler ve kullanılmayanları kaldırır.</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="29"/>
         <source>Enable update imports line, adding missing ones and removing unreferenced ones.</source>
-        <translation>Import sat&#305;rlar&#305;n&#305; güncellemeyi etkinle&#351;tir.</translation>
+        <translation>Import satırlarını güncellemeyi etkinleştir.</translation>
     </message>
     <message>
         <source>Use goimports instead of gofmt, for code formatting</source>
         <oldsource>Use goimports instead of gofmt,for code formatting</oldsource>
-        <translation>Kodu formatlamak i&#231;in gofmt yerine goimports kullan</translation>
+        <translation>Kodu formatlamak için gofmt yerine goimports kullan</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="36"/>
         <source>Enable sort imports of consecutive import lines in import blocks</source>
-        <oldsource>Import bloklar&#305;nda ard&#305;&#351;&#305;k import sat&#305;rlar&#305;n&#305; etkinle&#351;tir</oldsource>
+        <oldsource>Import bloklarında ardışık import satırlarını etkinleştir</oldsource>
         <translation></translation>
     </message>
     <message>
         <source>Use diff tool for faster formatting (requires diff program in PATH)</source>
-        <translation>Daha h&#305;zl&#305; formatlama i&#231;in diff program&#305; kullan (PATH i&#231;inde diff yolu bulunmal&#305;d&#305;r)</translation>
+        <translation>Daha hızlı formatlama için diff programı kullan (PATH içinde diff yolu bulunmalıdır)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="53"/>
@@ -1909,7 +1909,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="68"/>
         <source>Synchronous code formatting timeout in milliseconds (500ms or more):</source>
-        <translation>Milisaniye cinsinden kod formatlama zamana&#351;&#305;m&#305; (&gt;= 500ms):</translation>
+        <translation>Milisaniye cinsinden kod formatlama zamanaşımı (&gt;= 500ms):</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="43"/>
@@ -1930,7 +1930,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtplugin.cpp" line="59"/>
         <source>Format Code (Adjusts Imports)</source>
-        <translation>Kodu Formatla (Importlar&#305; ayarla)</translation>
+        <translation>Kodu Formatla (Importları ayarla)</translation>
     </message>
 </context>
 <context>
@@ -1938,7 +1938,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="64"/>
         <source>Bölüm (s1)</source>
-        <translation>K&#305;s&#305;m (s1)</translation>
+        <translation>Kısım (s1)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="67"/>
@@ -1953,43 +1953,43 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="73"/>
         <source>Bold</source>
-        <translation>Kal&#305;n</translation>
+        <translation>Kalın</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="76"/>
         <source>Italic</source>
-        <translation>&#304;talik</translation>
+        <translation>İtalik</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="79"/>
         <source>Inline Code</source>
-        <translation>Sat&#305;ri&#231;i Kod</translation>
+        <translation>Satıriçi Kod</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="82"/>
         <source>Switch Bullets</source>
-        <translation>Switch Noktalar&#305;</translation>
+        <translation>Switch Noktaları</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="85"/>
         <source>Comment/Uncomment Selection</source>
-        <translation>Se&#231;ilen yorumlar&#305; a&#231;/kapat</translation>
+        <translation>Seçilen yorumları aç/kapat</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="88"/>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="267"/>
         <source>Export HTML</source>
-        <translation>HTML Olarak D&#305;&#351;a Aktar</translation>
+        <translation>HTML Olarak Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="91"/>
         <source>Verify Present</source>
-        <translation>Durumu Do&#287;rula</translation>
+        <translation>Durumu Doğrula</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="256"/>
         <source>Present verify success</source>
-        <translation>Durum do&#287;rulama ba&#351;ar&#305;l&#305;</translation>
+        <translation>Durum doğrulama başarılı</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="258"/>
@@ -1999,7 +1999,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="310"/>
         <source>Export PDF</source>
-        <translation>PDF Olarak D&#305;&#351;a Aktar</translation>
+        <translation>PDF Olarak Dışa Aktar</translation>
     </message>
 </context>
 <context>
@@ -2013,7 +2013,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="84"/>
         <source>Run</source>
-        <translation>&#199;al&#305;&#351;t&#305;r</translation>
+        <translation>Çalıştır</translation>
     </message>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="85"/>
@@ -2038,7 +2038,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="89"/>
         <source>Explore Folder</source>
-        <translation>Dizini A&#231;</translation>
+        <translation>Dizini Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="168"/>
@@ -2046,7 +2046,7 @@ Dosya i&#231;eri&#287;i diskten okunarak güncellensin mi?</translation>
         <oldsource>Running...
 
 </oldsource>
-        <translation>&#199;al&#305;&#351;&#305;yor...</translation>
+        <translation>Çalışıyor...</translation>
     </message>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="192"/>
@@ -2060,7 +2060,7 @@ Error: %1.</oldsource>
         <source>Success: %2.</source>
         <oldsource>
 Success: %2.</oldsource>
-        <translation>Ba&#351;ar&#305;l&#305;: %2.</translation>
+        <translation>Başarılı: %2.</translation>
     </message>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="244"/>
@@ -2070,17 +2070,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="244"/>
         <source>Select a file to load:</source>
-        <translation>Yüklenecek dosyay&#305; se&#231;:</translation>
+        <translation>Yüklenecek dosyayı seç:</translation>
     </message>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="260"/>
         <source>Save File</source>
-        <translation>Dosyay&#305; Kaydet</translation>
+        <translation>Dosyayı Kaydet</translation>
     </message>
     <message>
         <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="260"/>
         <source>New File Name:</source>
-        <translation>Yeni dosya ad&#305;:</translation>
+        <translation>Yeni dosya adı:</translation>
     </message>
 </context>
 <context>
@@ -2099,23 +2099,23 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="77"/>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="381"/>
         <source>Export Html</source>
-        <translation>HTML Olarak D&#305;&#351;a Aktar</translation>
+        <translation>HTML Olarak Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="78"/>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="413"/>
         <source>Export PDF</source>
-        <translation>PDF Olarak D&#305;&#351;a Aktar</translation>
+        <translation>PDF Olarak Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="79"/>
         <source>Print Preview</source>
-        <translation>Bask&#305; Önizleme</translation>
+        <translation>Baskı Önizleme</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="82"/>
         <source>Synchronize preview and code scrollbars</source>
-        <translation>Önizleme ve kod kayd&#305;rma &#231;ubuklar&#305;n&#305; senkronize et</translation>
+        <translation>Önizleme ve kod kaydırma çubuklarını senkronize et</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="88"/>
@@ -2130,7 +2130,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="389"/>
         <source>Export Failed</source>
-        <translation>D&#305;&#351;a aktarma ba&#351;ar&#305;s&#305;z</translation>
+        <translation>Dışa aktarma başarısız</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="85"/>
@@ -2148,7 +2148,7 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="390"/>
         <source>Could not open %1 for writing!</source>
         <oldsource>Can not write file %1</oldsource>
-        <translation>%1 dosyas&#305; yazmak i&#231;in a&#231;&#305;lam&#305;yor!</translation>
+        <translation>%1 dosyası yazmak için açılamıyor!</translation>
     </message>
 </context>
 <context>
@@ -2156,7 +2156,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/golangcode/golangcode.cpp" line="657"/>
         <source>warning, pkg not find, please enter to import :</source>
-        <translation>Uyar&#305;: Pkg bulunamad&#305;, i&#231;eri aktarmak i&#231;in enter:</translation>
+        <translation>Uyarı: Pkg bulunamadı, içeri aktarmak için enter:</translation>
     </message>
 </context>
 <context>
@@ -2164,17 +2164,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/jsonedit/jsonedit.cpp" line="51"/>
         <source>Verify</source>
-        <translation>Do&#287;rula</translation>
+        <translation>Doğrula</translation>
     </message>
     <message>
         <location filename="src/plugins/jsonedit/jsonedit.cpp" line="53"/>
         <source>Format Json</source>
-        <translation>Json Bi&#231;imlendir</translation>
+        <translation>Json Biçimlendir</translation>
     </message>
     <message>
         <location filename="src/plugins/jsonedit/jsonedit.cpp" line="55"/>
         <source>Compact Json</source>
-        <translation>S&#305;k&#305;&#351;t&#305;r&#305;lm&#305;&#351; Json</translation>
+        <translation>Sıkıştırılmış Json</translation>
     </message>
 </context>
 <context>
@@ -2182,47 +2182,47 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="212"/>
         <source>Event Log</source>
-        <translation>Olay Günlü&#287;ü</translation>
+        <translation>Olay Günlüğü</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="199"/>
         <source>Escape</source>
-        <translation>&#304;ptal</translation>
+        <translation>İptal</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="635"/>
         <source>Close File</source>
-        <translation>Dosyay&#305; Kapat</translation>
+        <translation>Dosyayı Kapat</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="638"/>
         <source>Close All Files</source>
-        <translation>Tüm Dosyalar&#305; Kapat</translation>
+        <translation>Tüm Dosyaları Kapat</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="648"/>
         <source>Save File</source>
-        <translation>Dosyay&#305; Kaydet</translation>
+        <translation>Dosyayı Kaydet</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="651"/>
         <source>Save File As...</source>
-        <translation>Dosyay&#305; Farkl&#305; Kaydet...</translation>
+        <translation>Dosyayı Farklı Kaydet...</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="654"/>
         <source>Save All Files</source>
-        <translation>Tüm Dosyalar&#305; Kaydet</translation>
+        <translation>Tüm Dosyaları Kaydet</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="641"/>
         <source>Open Project</source>
-        <translation>Proje A&#231;</translation>
+        <translation>Proje Aç</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="214"/>
         <source>Options</source>
-        <translation>Se&#231;enekler</translation>
+        <translation>Seçenekler</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="612"/>
@@ -2232,17 +2232,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="615"/>
         <source>Open File...</source>
-        <translation>Dosya A&#231;...</translation>
+        <translation>Dosya Aç...</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="618"/>
         <source>Open Folder...</source>
-        <translation>Dizin A&#231;...</translation>
+        <translation>Dizin Aç...</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="621"/>
         <source>Open Folder in New Window...</source>
-        <translation>Dizini Yeni Pencerede A&#231;...</translation>
+        <translation>Dizini Yeni Pencerede Aç...</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="626"/>
@@ -2273,7 +2273,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="657"/>
         <source>Exit</source>
-        <translation>&#199;&#305;k&#305;&#351;</translation>
+        <translation>Çıkış</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="660"/>
@@ -2283,12 +2283,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="664"/>
         <source>About LiteIDE</source>
-        <translation>LiteIDE Hakk&#305;nda</translation>
+        <translation>LiteIDE Hakkında</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteapp.cpp" line="670"/>
         <source>About Plugins</source>
-        <translation>Eklentiler Hakk&#305;nda</translation>
+        <translation>Eklentiler Hakkında</translation>
     </message>
 </context>
 <context>
@@ -2313,7 +2313,7 @@ Success: %2.</oldsource>
         <location filename="src/liteapp/liteappoption.ui" line="239"/>
         <source>Recent Files</source>
         <oldsource>Recent File</oldsource>
-        <translation>Son Kullan&#305;lan Dosyalar</translation>
+        <translation>Son Kullanılan Dosyalar</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="245"/>
@@ -2324,11 +2324,11 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="128"/>
         <source>Monitoring files for modifications</source>
-        <translation>Dosyalar&#305;n de&#287;i&#351;ip de&#287;i&#351;medi&#287;ini gözlemle</translation>
+        <translation>Dosyaların değişip değişmediğini gözlemle</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="41"/>
-        <source>Ayarlar&#305; lokal bir ini dosyas&#305;nda sakla</source>
+        <source>Ayarları lokal bir ini dosyasında sakla</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2350,7 +2350,7 @@ Success: %2.</oldsource>
         <location filename="src/liteapp/liteappoption.ui" line="134"/>
         <source>Auto reload or close editor buffer,if underlying file is modified/deleted.</source>
         <oldsource>Auto reload editor buffer from disk file,if underlying file is modified/deleted.</oldsource>
-        <translation>A&#231;&#305;k dosya arkaplanda de&#287;i&#351;ir/silinirse editör önbelle&#287;ini diskten okuyarak güncelle.</translation>
+        <translation>Açık dosya arkaplanda değişir/silinirse editör önbelleğini diskten okuyarak güncelle.</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="163"/>
@@ -2361,12 +2361,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="200"/>
         <source>Reload folders on startup</source>
-        <translation>A&#231;&#305;l&#305;&#351;ta dizinleri yeniden yükle</translation>
+        <translation>Açılışta dizinleri yeniden yükle</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="227"/>
         <source>Reload files on startup</source>
-        <translation>A&#231;&#305;l&#305;&#351;ta dosyalar&#305; yeniden yükle</translation>
+        <translation>Açılışta dosyaları yeniden yükle</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="306"/>
@@ -2381,12 +2381,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="318"/>
         <source>Show splash screen on startup</source>
-        <translation>A&#231;&#305;l&#305;&#351;ta splash penceresini göster</translation>
+        <translation>Açılışta splash penceresini göster</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="325"/>
         <source>Show welcome page on startup</source>
-        <translation>A&#231;&#305;l&#305;&#351;ta ho&#351;geldin sayfas&#305;n&#305; göster</translation>
+        <translation>Açılışta hoşgeldin sayfasını göster</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="335"/>
@@ -2402,12 +2402,12 @@ Success: %2.</oldsource>
         <location filename="src/liteapp/liteappoption.ui" line="348"/>
         <source>Enable mouse wheel navigation on tabs</source>
         <oldsource>Enable mouse wheel selected on tab</oldsource>
-        <translation>Fare tekerle&#287;i ile sekmeler aras&#305; gezintiyi etkinle&#351;tir</translation>
+        <translation>Fare tekerleği ile sekmeler arası gezintiyi etkinleştir</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="358"/>
         <source>Toolbar Icon Size [*]</source>
-        <translation>Ara&#231; &#199;ubu&#287;u &#304;konlar&#305;</translation>
+        <translation>Araç Çubuğu İkonları</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="431"/>
@@ -2422,27 +2422,27 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="449"/>
         <source>Hide standard commands</source>
-        <translation>Standart komutlar&#305; gizle</translation>
+        <translation>Standart komutları gizle</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="456"/>
         <source>Reset</source>
-        <translation>S&#305;f&#305;rla</translation>
+        <translation>Sıfırla</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="463"/>
         <source>Reset All</source>
-        <translation>Tümünü S&#305;f&#305;rla</translation>
+        <translation>Tümünü Sıfırla</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="483"/>
         <source>Import...</source>
-        <translation>&#304;&#231;e Aktar...</translation>
+        <translation>İçe Aktar...</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="490"/>
         <source>Export...</source>
-        <translation>D&#305;&#351;a Aktar...</translation>
+        <translation>Dışa Aktar...</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="24"/>
@@ -2458,7 +2458,7 @@ Success: %2.</oldsource>
         <location filename="src/liteapp/liteappoption.ui" line="175"/>
         <source>Reload session on startup</source>
         <oldsource>Auto load last session</oldsource>
-        <translation>A&#231;&#305;l&#305;&#351;ta oturumu yeniden yükle</translation>
+        <translation>Açılışta oturumu yeniden yükle</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="85"/>
@@ -2468,7 +2468,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="86"/>
         <source>SplitterStyle</source>
-        <translation>Ay&#305;ra&#231; Stili</translation>
+        <translation>Ayıraç Stili</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="140"/>
@@ -2483,7 +2483,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="142"/>
         <source>Shortcuts</source>
-        <translation>K&#305;sayollar</translation>
+        <translation>Kısayollar</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="143"/>
@@ -2493,28 +2493,28 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="412"/>
         <source>Import Keyboard Mapping Scheme</source>
-        <translation>Klavye k&#305;sayol &#351;emas&#305;n&#305; i&#231;e aktar</translation>
+        <translation>Klavye kısayol şemasını içe aktar</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="412"/>
         <location filename="src/liteapp/liteappoption.cpp" line="446"/>
         <source>Keyboard Mapping Scheme (%1)</source>
-        <translation>Klavye K&#305;sayol &#350;emas&#305; (%1)</translation>
+        <translation>Klavye Kısayol Şeması (%1)</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="419"/>
         <source>Could not read scheme from %1!</source>
-        <translation>%1 yolundaki &#351;ema okunam&#305;yor!</translation>
+        <translation>%1 yolundaki şema okunamıyor!</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="446"/>
         <source>Export Keyboard Mapping Scheme</source>
-        <translation>Klavye k&#305;sayol &#351;emas&#305;n&#305; d&#305;&#351;ar&#305; aktar</translation>
+        <translation>Klavye kısayol şemasını dışarı aktar</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.cpp" line="457"/>
         <source>Could not write scheme to %1!</source>
-        <translation>&#350;ema %1 dosyas&#305;na yaz&#305;lam&#305;yor!</translation>
+        <translation>Şema %1 dosyasına yazılamıyor!</translation>
     </message>
 </context>
 <context>
@@ -2522,7 +2522,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="139"/>
         <source>Build Toolbar</source>
-        <translation>Derleme Ara&#231; &#199;ubu&#287;u</translation>
+        <translation>Derleme Araç Çubuğu</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="144"/>
@@ -2534,20 +2534,20 @@ Success: %2.</oldsource>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="154"/>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="158"/>
         <source>Name</source>
-        <translation>&#304;sim</translation>
+        <translation>İsim</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="151"/>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="155"/>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="159"/>
         <source>Value</source>
-        <translation>De&#287;er</translation>
+        <translation>Değer</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="163"/>
         <source>Build Configuration...</source>
         <oldsource>Build Config</oldsource>
-        <translation>Derleme ayarlar&#305;...</translation>
+        <translation>Derleme ayarları...</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="177"/>
@@ -2558,12 +2558,12 @@ Success: %2.</oldsource>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="181"/>
         <source>Clear Output</source>
         <oldsource>Clear All</oldsource>
-        <translation>&#199;&#305;kt&#305;y&#305; Temizle</translation>
+        <translation>Çıktıyı Temizle</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="185"/>
         <source>Execute File</source>
-        <translation>Dosya &#199;al&#305;&#351;t&#305;r</translation>
+        <translation>Dosya Çalıştır</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="188"/>
@@ -2598,7 +2598,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="216"/>
         <source>Line Wrap</source>
-        <translation>Sat&#305;r Kayd&#305;rma</translation>
+        <translation>Satır Kaydırma</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="220"/>
@@ -2614,13 +2614,13 @@ Success: %2.</oldsource>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="238"/>
         <source>Build Output</source>
         <oldsource>Build</oldsource>
-        <translation>Derleme &#199;&#305;kt&#305;s&#305;</translation>
+        <translation>Derleme Çıktısı</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="591"/>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="597"/>
         <source>Current environment change id &quot;%1&quot;</source>
-        <translation>Mevcut &#231;al&#305;&#351;ma ortam&#305; de&#287;i&#351;ilik no &quot;%1&quot;</translation>
+        <translation>Mevcut çalışma ortamı değişilik no &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="927"/>
@@ -2638,12 +2638,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="1269"/>
         <source>Command exited with code %1.</source>
-        <translation>Komutun &#231;al&#305;&#351;mas&#305; %1 koduyla sonland&#305;.</translation>
+        <translation>Komutun çalışması %1 koduyla sonlandı.</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="1271"/>
         <source>Success: %1.</source>
-        <oldsource>Ba&#351;ar&#305;l&#305;: %1.
+        <oldsource>Başarılı: %1.
 </oldsource>
         <translation type="unfinished">Erfolg: %1.</translation>
     </message>
@@ -2653,7 +2653,7 @@ Success: %2.</oldsource>
         <source>A process is currently running.  Stop the current action first.</source>
         <oldsource>A process is currently running.  Stop the current action first.
 </oldsource>
-        <translation>&#350;u an bir proses zaten &#231;al&#305;&#351;&#305;yor.. Önce bu eylemi durdurun.</translation>
+        <translation>Şu an bir proses zaten çalışıyor.. Önce bu eylemi durdurun.</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="1353"/>
@@ -2667,26 +2667,26 @@ Success: %2.</oldsource>
         <source>Failed to terminate the existing process!</source>
         <oldsource>Failed to terminate the existing process!
 </oldsource>
-        <translation>Mevcut prosesin durdurulmas&#305; ba&#351;ar&#305;s&#305;z!</translation>
+        <translation>Mevcut prosesin durdurulması başarısız!</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="1454"/>
         <source>&gt; Could not parse action &apos;%1&apos;</source>
         <oldsource>&gt; Could not parse action &apos;%1&apos;
 </oldsource>
-        <translation>&gt; Eylem &apos;%1&apos; okunam&#305;yor</translation>
+        <translation>&gt; Eylem &apos;%1&apos; okunamıyor</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="1500"/>
         <source>Started process successfully</source>
         <oldsource>Started process successfully
 </oldsource>
-        <translation>Proses ba&#351;latma ba&#351;ar&#305;l&#305;</translation>
+        <translation>Proses başlatma başarılı</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="1500"/>
         <source>Failed to start process</source>
-        <translation>Proses ba&#351;lat&#305;lam&#305;yor</translation>
+        <translation>Proses başlatılamıyor</translation>
     </message>
 </context>
 <context>
@@ -2700,13 +2700,13 @@ Success: %2.</oldsource>
         <location filename="src/plugins/litebuild/litebuildoption.ui" line="20"/>
         <source>Recheck Go installation when changing environments</source>
         <oldsource>Recheck go env if enviroment changed</oldsource>
-        <translation>&#199;al&#305;&#351;ma ortam&#305; de&#287;i&#351;ikli&#287;inde Go kurulumunu kontrol et</translation>
+        <translation>Çalışma ortamı değişikliğinde Go kurulumunu kontrol et</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuildoption.ui" line="27"/>
         <source>Build command configuration files [*]</source>
         <oldsource>Build command configuration files:</oldsource>
-        <translation>Komut ayarlar&#305; dosyalar&#305;n&#305; derle:</translation>
+        <translation>Komut ayarları dosyalarını derle:</translation>
     </message>
 </context>
 <context>
@@ -2720,13 +2720,13 @@ Success: %2.</oldsource>
         <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="104"/>
         <source>Execute:</source>
         <oldsource>Exec:</oldsource>
-        <translation>&#199;al&#305;&#351;t&#305;r:</translation>
+        <translation>Çalıştır:</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="111"/>
         <source>Execute File</source>
         <oldsource>Execute</oldsource>
-        <translation>Dosyay&#305; &#199;al&#305;&#351;t&#305;r</translation>
+        <translation>Dosyayı Çalıştır</translation>
     </message>
 </context>
 <context>
@@ -2749,19 +2749,19 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="119"/>
         <source>Show Current Line</source>
-        <translation>Mevcut Sat&#305;r&#305; Göster</translation>
+        <translation>Mevcut Satırı Göster</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="194"/>
         <source>Debug Output</source>
         <oldsource>Debug</oldsource>
-        <translation>Hata Ay&#305;klama &#199;&#305;kt&#305;s&#305;</translation>
+        <translation>Hata Ayıklama Çıktısı</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="103"/>
         <source>Start Debugging External Application...</source>
         <oldsource>Start Debugging External Application</oldsource>
-        <translation>Hata Ay&#305;klamay&#305; Harici Uygulamada Ba&#351;lat...</translation>
+        <translation>Hata Ayıklamayı Harici Uygulamada Başlat...</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="91"/>
@@ -2771,17 +2771,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="106"/>
         <source>Start Debugging</source>
-        <translation>Hata Ay&#305;klamaya Ba&#351;la</translation>
+        <translation>Hata Ayıklamaya Başla</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="109"/>
         <source>Start Debugging Tests</source>
-        <translation>Hata Ay&#305;klama Testlerine Ba&#351;la</translation>
+        <translation>Hata Ayıklama Testlerine Başla</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="122"/>
         <source>Step Into</source>
-        <translation>&#304;&#231;ine Ad&#305;m</translation>
+        <translation>İçine Adım</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="125"/>
@@ -2791,27 +2791,27 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="128"/>
         <source>Step Out</source>
-        <translation>D&#305;&#351;a Ad&#305;m</translation>
+        <translation>Dışa Adım</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="131"/>
         <source>Run to Line</source>
-        <translation>Sat&#305;ra kadar &#199;al&#305;&#351;</translation>
+        <translation>Satıra kadar Çalış</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="134"/>
         <source>Insert/Remove Breakpoint</source>
-        <translation>Kesme noktas&#305; ekle/kald&#305;r</translation>
+        <translation>Kesme noktası ekle/kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="137"/>
         <source>Remove All Breakpoints</source>
-        <translation>Tüm Kesme Noktalar&#305;n&#305; Kald&#305;r</translation>
+        <translation>Tüm Kesme Noktalarını Kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebug.cpp" line="156"/>
         <source>&amp;Debug</source>
-        <translation>&amp;Hata Ay&#305;kla</translation>
+        <translation>&amp;Hata Ayıkla</translation>
     </message>
 </context>
 <context>
@@ -2824,13 +2824,13 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litedebug/litedebugoption.ui" line="20"/>
         <source>Debug</source>
-        <translation>Hata Ay&#305;kla</translation>
+        <translation>Hata Ayıkla</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebugoption.ui" line="26"/>
         <source>Rebuild before debugging</source>
         <oldsource>Debug before rebuild</oldsource>
-        <translation>Hata ay&#305;klamadan önce yeniden derle</translation>
+        <translation>Hata ayıklamadan önce yeniden derle</translation>
     </message>
 </context>
 <context>
@@ -2839,7 +2839,7 @@ Success: %2.</oldsource>
         <location filename="src/plugins/litedebug/litedebugplugin.cpp" line="58"/>
         <source>Debug Window</source>
         <oldsource>Debug</oldsource>
-        <translation>Hata Ay&#305;klama Penceresi</translation>
+        <translation>Hata Ayıklama Penceresi</translation>
     </message>
 </context>
 <context>
@@ -2848,7 +2848,7 @@ Success: %2.</oldsource>
         <location filename="src/plugins/welcome/litedoc.cpp" line="63"/>
         <source>LiteIDE Documentation</source>
         <oldsource>LiteIDE Document Browser</oldsource>
-        <translation>LiteIDE Dökümanlar&#305;</translation>
+        <translation>LiteIDE Dökümanları</translation>
     </message>
 </context>
 <context>
@@ -2876,17 +2876,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="253"/>
         <source>Paste</source>
-        <translation>Yap&#305;&#351;t&#305;r</translation>
+        <translation>Yapıştır</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="256"/>
         <source>Select All</source>
-        <translation>Tümünü Se&#231;</translation>
+        <translation>Tümünü Seç</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="337"/>
         <source>Word Wrap (MimeType)</source>
-        <translation>Sat&#305;r Kayd&#305;rma (MimeTipi)</translation>
+        <translation>Satır Kaydırma (MimeTipi)</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="348"/>
@@ -2901,58 +2901,58 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="354"/>
         <source>Auto-indent Selection</source>
-        <translation>Se&#231;imi Otomatik Hizala</translation>
+        <translation>Seçimi Otomatik Hizala</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="358"/>
         <source>Tab To Spaces (MimeType)</source>
-        <translation>Tab-Bo&#351;luk Dönü&#351;ümü (MimeTipi)</translation>
+        <translation>Tab-Boşluk Dönüşümü (MimeTipi)</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="362"/>
         <source>Line End Windows (\r\n)</source>
-        <translation>Windows sat&#305;r sonu (\r\n)</translation>
+        <translation>Windows satır sonu (\r\n)</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="366"/>
         <source>Line End Unix (\n)</source>
-        <translation>Unix sat&#305;r sonu (\n)</translation>
+        <translation>Unix satır sonu (\n)</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="370"/>
         <source>Visualize Whitespace (Global)</source>
-        <translation>Bo&#351;luklar&#305; Görünür Yap (Genel)</translation>
+        <translation>Boşlukları Görünür Yap (Genel)</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="377"/>
         <source>Move Line Up</source>
-        <translation>Sat&#305;r&#305; Yukar&#305; Ta&#351;&#305;</translation>
+        <translation>Satırı Yukarı Taşı</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="380"/>
         <source>Move Line Down</source>
-        <translation>Sat&#305;r&#305; A&#351;a&#287;&#305; Ta&#351;&#305;</translation>
+        <translation>Satırı Aşağı Taşı</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="383"/>
         <source>Copy Line Up</source>
-        <translation>Sat&#305;r&#305; Yukar&#305; Kopyala</translation>
+        <translation>Satırı Yukarı Kopyala</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="386"/>
         <source>Copy Line Down</source>
-        <translation>Sat&#305;r&#305; A&#351;a&#287;&#305; Kopyala</translation>
+        <translation>Satırı Aşağı Kopyala</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="389"/>
         <source>Join Lines</source>
-        <translation>Sat&#305;rlar&#305; Birle&#351;tir</translation>
+        <translation>Satırları Birleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="544"/>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="606"/>
         <source>Advanced</source>
-        <translation>Geli&#351;mi&#351;</translation>
+        <translation>Gelişmiş</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="574"/>
@@ -2963,65 +2963,65 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="981"/>
         <source>Export HTML</source>
-        <translation>HTML Olarak D&#305;&#351;a Aktar</translation>
+        <translation>HTML Olarak Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="989"/>
         <source>Export Failed</source>
-        <translation>D&#305;&#351;a Aktarma Ba&#351;ar&#305;s&#305;z</translation>
+        <translation>Dışa Aktarma Başarısız</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="990"/>
         <source>Could not open %1 for writing.</source>
-        <translation>%1 dosyas&#305; yazmak i&#231;in a&#231;&#305;lam&#305;yor.</translation>
+        <translation>%1 dosyası yazmak için açılamıyor.</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1009"/>
         <source>Export PDF</source>
-        <translation>PDF Olarak D&#305;&#351;a Aktar</translation>
+        <translation>PDF Olarak Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1034"/>
         <source>Print Document</source>
-        <translation>Döküman&#305; Yazd&#305;r</translation>
+        <translation>Dökümanı Yazdır</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="263"/>
         <source>Print Preview...</source>
         <oldsource>Print Preview Document</oldsource>
-        <translation>Döküman Bask&#305; Önizleme...</translation>
+        <translation>Döküman Baskı Önizleme...</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="259"/>
         <source>Export HTML...</source>
-        <translation>HTML Olarak D&#305;&#351;a Aktar...</translation>
+        <translation>HTML Olarak Dışa Aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="261"/>
         <source>Export PDF...</source>
-        <translation>PDF Olarak D&#305;&#351;a Aktar...</translation>
+        <translation>PDF Olarak Dışa Aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="262"/>
         <source>Print...</source>
-        <translation>Yazd&#305;r...</translation>
+        <translation>Yazdır...</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="265"/>
         <source>Go To Previous Block</source>
         <oldsource>Goto Previous Block</oldsource>
-        <translation>Bir Önceki Blo&#287;a Git</translation>
+        <translation>Bir Önceki Bloğa Git</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="272"/>
         <source>Select Block</source>
-        <translation>Blo&#287;u Se&#231;</translation>
+        <translation>Bloğu Seç</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="275"/>
         <source>Go To Matching Brace</source>
         <oldsource>Goto Match Brace</oldsource>
-        <translation>E&#351;le&#351;en Paranteze Git</translation>
+        <translation>Eşleşen Paranteze Git</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="278"/>
@@ -3048,7 +3048,7 @@ Success: %2.</oldsource>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1093"/>
         <source>Go To Line</source>
         <oldsource>Goto Line</oldsource>
-        <translation>Sat&#305;ra Git</translation>
+        <translation>Satıra Git</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="298"/>
@@ -3058,52 +3058,52 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="301"/>
         <source>Duplicate</source>
-        <translation>Kopyas&#305;n&#305; Al</translation>
+        <translation>Kopyasını Al</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="305"/>
         <source>Delete Line</source>
-        <translation>Sat&#305;r&#305; Sil</translation>
+        <translation>Satırı Sil</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="309"/>
         <source>Copy Line</source>
-        <translation>Sat&#305;r&#305; Kopyala</translation>
+        <translation>Satırı Kopyala</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="313"/>
         <source>Cut Line</source>
-        <translation>Sat&#305;r&#305; Kes</translation>
+        <translation>Satırı Kes</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="317"/>
         <source>Insert Line Before</source>
-        <translation>Önüne sat&#305;r ekle</translation>
+        <translation>Önüne satır ekle</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="321"/>
         <source>Insert Line After</source>
-        <translation>Arkas&#305;na sat&#305;r ekle</translation>
+        <translation>Arkasına satır ekle</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="325"/>
         <source>Increase Font Size</source>
-        <translation>Yaz&#305;tipini Büyüt</translation>
+        <translation>Yazıtipini Büyüt</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="328"/>
         <source>Decrease Font Size</source>
-        <translation>Yaz&#305;tipini Kü&#231;ült</translation>
+        <translation>Yazıtipini Küçült</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="331"/>
         <source>Reset Font Size</source>
-        <translation>Yaz&#305;tipi Boyutunu S&#305;f&#305;rla</translation>
+        <translation>Yazıtipi Boyutunu Sıfırla</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="334"/>
         <source>Clean Whitespace</source>
-        <translation>Bo&#351;luklar&#305; Temizle</translation>
+        <translation>Boşlukları Temizle</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="341"/>
@@ -3113,18 +3113,18 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="704"/>
         <source>Reload File</source>
-        <translation>Dosyay&#305; Yenile</translation>
+        <translation>Dosyayı Yenile</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1051"/>
         <source>Do you want to permanently discard unsaved modifications and reload %1?</source>
-        <translation>Kaydedilmemi&#351; de&#287;i&#351;iklikleri gözard&#305; edip %1 dosyas&#305;n&#305; yeniden yüklemek istedi&#287;inize emin misiniz?</translation>
+        <translation>Kaydedilmemiş değişiklikleri gözardı edip %1 dosyasını yeniden yüklemek istediğinize emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="268"/>
         <source>Go To Next Block</source>
         <oldsource>Goto Next Block</oldsource>
-        <translation>Bir Sonraki Blo&#287;a Git</translation>
+        <translation>Bir Sonraki Bloğa Git</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="580"/>
@@ -3139,7 +3139,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1093"/>
         <source>Line: </source>
-        <translation>Sat&#305;r: </translation>
+        <translation>Satır: </translation>
     </message>
 </context>
 <context>
@@ -3157,17 +3157,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="355"/>
         <source>Check and convert no printable char to &apos;.&apos;</source>
-        <translation>Görüntülenmeyen karakterleri yakala ve &apos;.&apos; ile de&#287;i&#351;tir</translation>
+        <translation>Görüntülenmeyen karakterleri yakala ve &apos;.&apos; ile değiştir</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="30"/>
         <source>Font</source>
-        <translation>Yaz&#305;tipi</translation>
+        <translation>Yazıtipi</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="24"/>
         <source>Font &amp;&amp; Colors</source>
-        <translation type="unfinished">Yaz&#305;tipi &amp;&amp; Renkler</translation>
+        <translation type="unfinished">Yazıtipi &amp;&amp; Renkler</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="36"/>
@@ -3192,13 +3192,13 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="96"/>
         <source>Antialias</source>
-        <translation>Yumu&#351;ak kenarlar</translation>
+        <translation>Yumuşak kenarlar</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="119"/>
         <source>Editor Color Scheme</source>
         <oldsource>ColorStyle Scheme</oldsource>
-        <translation>Editör Renk &#350;emas&#305;</translation>
+        <translation>Editör Renk Şeması</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="127"/>
@@ -3219,32 +3219,32 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="312"/>
         <source>Clean whitespace when saving files</source>
-        <translation>Dosyalar&#305; kaydederken gereksiz bo&#351;luklar&#305; sil</translation>
+        <translation>Dosyaları kaydederken gereksiz boşlukları sil</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="319"/>
         <source>Enable scroll wheel zooming</source>
-        <translation>Fare terkerle&#287;i ile zoom etkin</translation>
+        <translation>Fare terkerleği ile zoom etkin</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="378"/>
         <source>Display VisualizeWhitespace</source>
-        <translation>Bo&#351;luklar&#305; Görselle&#351;tir</translation>
+        <translation>Boşlukları Görselleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="392"/>
         <source>Word wrap by default</source>
-        <translation>Varsay&#305;lan olarak sat&#305;rlar&#305; kayd&#305;r</translation>
+        <translation>Varsayılan olarak satırları kaydır</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="371"/>
         <source>Display code fold</source>
-        <translation>Kod katlamay&#305; göster</translation>
+        <translation>Kod katlamayı göster</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="450"/>
         <source>Display offset position</source>
-        <translation>Kenar bo&#351;lu&#287;u konumunu göster</translation>
+        <translation>Kenar boşluğu konumunu göster</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="474"/>
@@ -3255,27 +3255,27 @@ Success: %2.</oldsource>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="183"/>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="258"/>
         <source>Behavior</source>
-        <translation>Davran&#305;&#351;</translation>
+        <translation>Davranış</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="385"/>
         <source>Display EOF</source>
-        <translation>Sat&#305;r sonu (EOF) karakterini göster</translation>
+        <translation>Satır sonu (EOF) karakterini göster</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="399"/>
         <source>Display line numbers</source>
-        <translation>Sat&#305;r numaralar&#305;n&#305; göster</translation>
+        <translation>Satır numaralarını göster</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="406"/>
         <source>Display indent guide </source>
-        <translation>Hizalama &#231;izgisini göster</translation>
+        <translation>Hizalama çizgisini göster</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="415"/>
         <source>Display right margin at column</source>
-        <translation>Sa&#287; marjini göster</translation>
+        <translation>Sağ marjini göster</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="264"/>
@@ -3287,13 +3287,13 @@ Success: %2.</oldsource>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="271"/>
         <source>Case sensitive code completion</source>
         <oldsource>Completer case sensitive</oldsource>
-        <translation>Kod tamamlarken Kü&#231;ük/BÜYÜK harfe duyarl&#305; ol</translation>
+        <translation>Kod tamamlarken Küçük/BÜYÜK harfe duyarlı ol</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="280"/>
         <source>Code completion prefix length:</source>
         <oldsource>Word Complete Prefix Length</oldsource>
-        <translation>Kod tamamlama i&#231;in karakter say&#305;s&#305;:</translation>
+        <translation>Kod tamamlama için karakter sayısı:</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="343"/>
@@ -3309,17 +3309,17 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="142"/>
         <source>Tab Width</source>
-        <translation>Tab Geni&#351;li&#287;i</translation>
+        <translation>Tab Genişliği</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="143"/>
         <source>Tab To Spaces</source>
-        <translation>Tab-Bo&#351;luk Dönü&#351;ümü</translation>
+        <translation>Tab-Boşluk Dönüşümü</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="144"/>
         <source>File Extensions</source>
-        <translation>Dosya Uzant&#305;lar&#305;</translation>
+        <translation>Dosya Uzantıları</translation>
     </message>
 </context>
 <context>
@@ -3332,12 +3332,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteenv/liteenvoption.ui" line="20"/>
         <source>Environment definition files:</source>
-        <translation>&#199;al&#305;&#351;ma ortam&#305; tan&#305;mlama dosyalar&#305;:</translation>
+        <translation>Çalışma ortamı tanımlama dosyaları:</translation>
     </message>
     <message>
         <location filename="src/plugins/liteenv/liteenvoption.ui" line="33"/>
         <source>Environment changes will take effect after switching environments.</source>
-        <translation>&#199;al&#305;&#351;ma ortam&#305; de&#287;i&#351;iklikleri &#231;al&#305;&#351;ma ortam&#305; de&#287;i&#351;tikten sonra ge&#231;erli olur.</translation>
+        <translation>Çalışma ortamı değişiklikleri çalışma ortamı değiştikten sonra geçerli olur.</translation>
     </message>
 </context>
 <context>
@@ -3365,7 +3365,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litefind/litefindplugin.cpp" line="81"/>
         <source>Replace</source>
-        <translation>De&#287;i&#351;tir</translation>
+        <translation>Değiştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/litefindplugin.cpp" line="84"/>
@@ -3378,7 +3378,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/litetabwidget.cpp" line="66"/>
         <source>Open a new tab</source>
-        <translation>Yeni bir sekme a&#231;</translation>
+        <translation>Yeni bir sekme aç</translation>
     </message>
     <message>
         <location filename="src/liteapp/litetabwidget.cpp" line="71"/>
@@ -3397,7 +3397,7 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="142"/>
         <source>Markdown Exporter</source>
         <oldsource>Markdown Batch</oldsource>
-        <translation>Markdown D&#305;&#351;a Aktar&#305;c&#305;</translation>
+        <translation>Markdown Dışa Aktarıcı</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="161"/>
@@ -3408,29 +3408,29 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="230"/>
         <source>Select the folder containing your markdown files:</source>
         <oldsource>Select Markdown Folder</oldsource>
-        <translation>Markdown dosyalar&#305;n&#305;z&#305; i&#231;eren dizini se&#231;in:</translation>
+        <translation>Markdown dosyalarınızı içeren dizini seçin:</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="241"/>
         <source>Select Markdown Files</source>
-        <translation>Markdown Dosyalar&#305;n&#305; Se&#231;</translation>
+        <translation>Markdown Dosyalarını Seç</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="289"/>
         <source>Select the folder to contain separated markdown exports:</source>
-        <translation>Markdown d&#305;&#351;a aktar&#305;mlar&#305; i&#231;in dizin se&#231;in:</translation>
+        <translation>Markdown dışa aktarımları için dizin seçin:</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="302"/>
         <source>Export Merged HTML</source>
         <oldsource>Export Html</oldsource>
-        <translation>Tek HTML Olarak D&#305;&#351;a Aktar</translation>
+        <translation>Tek HTML Olarak Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="377"/>
         <source>Export Merged PDF</source>
         <oldsource>Export PDF</oldsource>
-        <translation>Tek PDF Olarak D&#305;&#351;a Aktar</translation>
+        <translation>Tek PDF Olarak Dışa Aktar</translation>
     </message>
 </context>
 <context>
@@ -3444,13 +3444,13 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="20"/>
         <source>Markdown Source Files</source>
         <oldsource>Markdown Files</oldsource>
-        <translation>Markdown Kaynak Dosyalar&#305;</translation>
+        <translation>Markdown Kaynak Dosyaları</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="38"/>
         <source>Import Folder...</source>
         <oldsource>Import Folder</oldsource>
-        <translation>&#304;&#231;e Aktarma Dizini...</translation>
+        <translation>İçe Aktarma Dizini...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="45"/>
@@ -3461,22 +3461,22 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="52"/>
         <source>Move Up</source>
-        <translation>Yukar&#305; Ta&#351;&#305;</translation>
+        <translation>Yukarı Taşı</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="59"/>
         <source>Move Down</source>
-        <translation>A&#351;a&#287;&#305; Ta&#351;&#305;</translation>
+        <translation>Aşağı Taşı</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="66"/>
         <source>Remove</source>
-        <translation>Kald&#305;r</translation>
+        <translation>Kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="73"/>
         <source>Remove All</source>
-        <translation>Tümünü Kald&#305;r</translation>
+        <translation>Tümünü Kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="98"/>
@@ -3486,7 +3486,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="106"/>
         <source>Export Folder:</source>
-        <translation>D&#305;&#351;a Aktarma Dizini:</translation>
+        <translation>Dışa Aktarma Dizini:</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="116"/>
@@ -3503,55 +3503,55 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="137"/>
         <source>Insert horizontal line between merged files</source>
         <oldsource>Merge files insert split &lt;hr&gt;</oldsource>
-        <translation>Birle&#351;en dosyalar&#305;n aras&#305;na &#231;izgi ekle</translation>
+        <translation>Birleşen dosyaların arasına çizgi ekle</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="144"/>
         <source>Insert page break between merged files</source>
         <oldsource>Merge files insert page break</oldsource>
-        <translation>Birle&#351;en dosyalar&#305;n aras&#305;na sayfa sonu i&#351;areti ekle</translation>
+        <translation>Birleşen dosyaların arasına sayfa sonu işareti ekle</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="169"/>
         <source>Export</source>
         <oldsource>Export Util</oldsource>
-        <translation>D&#305;&#351;a Aktar</translation>
+        <translation>Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="175"/>
         <source>Export Separated HTML</source>
         <oldsource>Separate Html</oldsource>
-        <translation>Ayr&#305; HTML D&#305;&#351;a Aktar</translation>
+        <translation>Ayrı HTML Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="182"/>
         <source>Export Separated PDF</source>
         <oldsource>Separate PDF</oldsource>
-        <translation>Ayr&#305; PDF D&#305;&#351;a Aktar</translation>
+        <translation>Ayrı PDF Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="189"/>
         <source>Export Merged HTML...</source>
         <oldsource>Merge Html</oldsource>
-        <translation>Birle&#351;tirilmi&#351; HTML Olarak D&#305;&#351;a Aktar...</translation>
+        <translation>Birleştirilmiş HTML Olarak Dışa Aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="196"/>
         <source>Export Merged PDF...</source>
         <oldsource>Merge PDF</oldsource>
-        <translation>Birle&#351;tirilmi&#351; PDF Olarak D&#305;&#351;a Aktar...</translation>
+        <translation>Birleştirilmiş PDF Olarak Dışa Aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="203"/>
         <source>Print Preview Merged...</source>
         <oldsource>Merge Print Preview</oldsource>
-        <translation>Birle&#351;tirilmi&#351; Bask&#305; Önizleme...</translation>
+        <translation>Birleştirilmiş Baskı Önizleme...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="210"/>
         <source>Print Merged</source>
         <oldsource>Merge Print</oldsource>
-        <translation>Birle&#351;tirerek Yazd&#305;r</translation>
+        <translation>Birleştirerek Yazdır</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="233"/>
@@ -3565,57 +3565,57 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="83"/>
         <source>Header (h1)</source>
         <oldsource>Header &lt;h1&gt;</oldsource>
-        <translation>Ba&#351;l&#305;k (h1)</translation>
+        <translation>Başlık (h1)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="86"/>
         <source>Header (h2)</source>
         <oldsource>Header &lt;h2&gt;</oldsource>
-        <translation>Ba&#351;l&#305;k (h2)</translation>
+        <translation>Başlık (h2)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="89"/>
         <source>Header (h3)</source>
         <oldsource>Header &lt;h3&gt;</oldsource>
-        <translation>Ba&#351;l&#305;k (h3)</translation>
+        <translation>Başlık (h3)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="92"/>
         <source>Header (h4)</source>
         <oldsource>Header &lt;h4&gt;</oldsource>
-        <translation>Ba&#351;l&#305;k (h4)</translation>
+        <translation>Başlık (h4)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="95"/>
         <source>Header (h5)</source>
         <oldsource>Header &lt;h5&gt;</oldsource>
-        <translation>Ba&#351;l&#305;k (h5)</translation>
+        <translation>Başlık (h5)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="98"/>
         <source>Header (h6)</source>
         <oldsource>Header &lt;h6&gt;</oldsource>
-        <translation>Ba&#351;l&#305;k (h6)</translation>
+        <translation>Başlık (h6)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="101"/>
         <source>Bold</source>
-        <translation>Kal&#305;n</translation>
+        <translation>Kalın</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="104"/>
         <source>Italic</source>
-        <translation>&#304;talik</translation>
+        <translation>İtalik</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="107"/>
         <source>Inline Code</source>
-        <translation>Sat&#305;r &#304;&#231;i Kod</translation>
+        <translation>Satır İçi Kod</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="110"/>
         <source>Link</source>
-        <translation>Ba&#287;lant&#305;</translation>
+        <translation>Bağlantı</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="113"/>
@@ -3625,28 +3625,28 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="116"/>
         <source>Unordered List</source>
-        <translation>S&#305;ras&#305;z Liste</translation>
+        <translation>Sırasız Liste</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="119"/>
         <source>Ordered List</source>
-        <translation>S&#305;ral&#305; Liste</translation>
+        <translation>Sıralı Liste</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="122"/>
         <source>Blockquote</source>
-        <translation>Al&#305;nt&#305;</translation>
+        <translation>Alıntı</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="125"/>
         <source>Horizontal Rule</source>
-        <translation>Yatay &#199;izgi</translation>
+        <translation>Yatay Çizgi</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="131"/>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="154"/>
         <source>Heading</source>
-        <translation>Ba&#351;lang&#305;&#231;</translation>
+        <translation>Başlangıç</translation>
     </message>
 </context>
 <context>
@@ -3685,7 +3685,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="87"/>
         <source>Name:</source>
-        <translation>&#304;sim:</translation>
+        <translation>İsim:</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="114"/>
@@ -3701,52 +3701,52 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="126"/>
         <source>Could not create the target directory: %1</source>
-        <translation>Hedef dizin yarat&#305;lam&#305;yor: %1</translation>
+        <translation>Hedef dizin yaratılamıyor: %1</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="131"/>
         <source>Warning</source>
-        <translation>Uyar&#305;</translation>
+        <translation>Uyarı</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="131"/>
         <source>Location %1 is not empty.
 Use the target directory anyway?</source>
-        <translation>%1 dizini bo&#351; de&#287;il.
-Yine de hedef dizin olarak kullan&#305;ls&#305;n m&#305;?</translation>
+        <translation>%1 dizini boş değil.
+Yine de hedef dizin olarak kullanılsın mı?</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="168"/>
         <source>Overwrite File</source>
-        <translation>Dosyan&#305;n Üzerine Yaz</translation>
+        <translation>Dosyanın Üzerine Yaz</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="168"/>
         <source>%1 already exists.
 Do you want to replace it?</source>
         <translation type="unfinished">%1 zaten mevcut.
-De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
+Değiştirilmesini istiyor musunuz?</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="184"/>
         <source>No files could be created.</source>
-        <translation>Hi&#231; dosya yarat&#305;lmad&#305;.</translation>
+        <translation>Hiç dosya yaratılmadı.</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="279"/>
         <source>File template details:</source>
-        <translation type="unfinished">Taslak dosya detaylar&#305;:</translation>
+        <translation type="unfinished">Taslak dosya detayları:</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="281"/>
         <source>Project template details:</source>
         <oldsource>New project wizard:</oldsource>
-        <translation>Taslak proje detaylar&#305;:</translation>
+        <translation>Taslak proje detayları:</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="359"/>
         <source>Choose a directory for the new content:</source>
-        <translation>Yeni i&#231;erik i&#231;in bir dizin se&#231;in:</translation>
+        <translation>Yeni içerik için bir dizin seçin:</translation>
     </message>
 </context>
 <context>
@@ -3774,7 +3774,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/liteapp/optionswidget.ui" line="72"/>
         <source>[*] item requeset restart LiteIDE</source>
         <oldsource>[*] item requeset restart liteide</oldsource>
-        <translation>[*] LiteIDE yeniden ba&#351;lat&#305;lmal&#305;d&#305;r</translation>
+        <translation>[*] LiteIDE yeniden başlatılmalıdır</translation>
     </message>
 </context>
 <context>
@@ -3787,7 +3787,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="20"/>
         <source>Font</source>
-        <translation>Yaz&#305;tipi</translation>
+        <translation>Yazıtipi</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="26"/>
@@ -3812,7 +3812,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="86"/>
         <source>Antialias</source>
-        <translation>Yumu&#351;ak kenarlar</translation>
+        <translation>Yumuşak kenarlar</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="109"/>
@@ -3822,12 +3822,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="115"/>
         <source>Use editor color scheme</source>
-        <translation>Editör renk &#351;emas&#305;n&#305; kullan</translation>
+        <translation>Editör renk şemasını kullan</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="124"/>
         <source>Sets the maximum number of lines</source>
-        <translation>Maksimum sat&#305;r say&#305;s&#305;n&#305; belirler</translation>
+        <translation>Maksimum satır sayısını belirler</translation>
     </message>
 </context>
 <context>
@@ -3851,7 +3851,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="92"/>
         <source>Load Package in New Window</source>
-        <translation>Paketi Yeni Pencerede A&#231;</translation>
+        <translation>Paketi Yeni Pencerede Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="93"/>
@@ -3861,13 +3861,13 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="94"/>
         <source>Open Source File</source>
-        <translation>Kaynak Dosyay&#305; A&#231;</translation>
+        <translation>Kaynak Dosyayı Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="95"/>
         <source>Copy Name to Clipboard</source>
         <oldsource>Copy Name To Clipboard</oldsource>
-        <translation>&#304;smi Kopyala</translation>
+        <translation>İsmi Kopyala</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="117"/>
@@ -3879,7 +3879,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="193"/>
         <source>No Go installation was found.</source>
         <oldsource>Not find go in PATH...</oldsource>
-        <translation>Go kurulumu bulunamad&#305;.</translation>
+        <translation>Go kurulumu bulunamadı.</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="198"/>
@@ -3898,7 +3898,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="77"/>
         <source>Open Explorer Here</source>
-        <translation>&#304;&#231;eren Dizini Göster</translation>
+        <translation>İçeren Dizini Göster</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="78"/>
@@ -3915,12 +3915,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="311"/>
         <source>File %1 already exists.</source>
-        <translation>%1 dosyas&#305; zaten mevcut.</translation>
+        <translation>%1 dosyası zaten mevcut.</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="316"/>
         <source>Could not open %1 for writing.</source>
-        <translation>%1 dosyas&#305; yazmak i&#231;in a&#231;&#305;lam&#305;yor.</translation>
+        <translation>%1 dosyası yazmak için açılamıyor.</translation>
     </message>
 </context>
 <context>
@@ -3939,12 +3939,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="51"/>
         <source>Name</source>
-        <translation>&#304;sim</translation>
+        <translation>İsim</translation>
     </message>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="54"/>
         <source>Author</source>
-        <translation>Geli&#351;tirici</translation>
+        <translation>Geliştirici</translation>
     </message>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="52"/>
@@ -3966,7 +3966,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/liteapp/pluginsdialog.cpp" line="56"/>
         <source>File Name</source>
         <oldsource>FileName</oldsource>
-        <translation>Dosya Ad&#305;</translation>
+        <translation>Dosya Adı</translation>
     </message>
 </context>
 <context>
@@ -3974,47 +3974,47 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="46"/>
         <source>process exited with code %1</source>
-        <translation>Prosesin &#231;al&#305;&#351;mas&#305; %1 koduyla sonland&#305;</translation>
+        <translation>Prosesin çalışması %1 koduyla sonlandı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="49"/>
         <source>process crashed or was terminated</source>
-        <translation>proses &#231;ak&#305;ld&#305; veya sonland&#305;r&#305;ld&#305;</translation>
+        <translation>proses çakıldı veya sonlandırıldı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="52"/>
         <source>process exited with an unknown status</source>
-        <translation>proses bilinmeyen bir durum koduyla sonland&#305;</translation>
+        <translation>proses bilinmeyen bir durum koduyla sonlandı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="62"/>
         <source>process failed to start</source>
-        <translation>proses ba&#351;latma ba&#351;ar&#305;s&#305;z</translation>
+        <translation>proses başlatma başarısız</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="65"/>
         <source>process crashed or was terminated while running</source>
-        <translation>proses &#231;al&#305;&#351;&#305;rken &#231;ak&#305;ld&#305; veya sonland&#305;r&#305;ld&#305;</translation>
+        <translation>proses çalışırken çakıldı veya sonlandırıldı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="68"/>
         <source>timed out waiting for process</source>
-        <translation>proses beklerken zamana&#351;&#305;m&#305;na u&#287;rad&#305;</translation>
+        <translation>proses beklerken zamanaşımına uğradı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="71"/>
         <source>couldn&apos;t read from the process</source>
-        <translation>prosesin &#231;&#305;kt&#305;s&#305; okunam&#305;yor</translation>
+        <translation>prosesin çıktısı okunamıyor</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="74"/>
         <source>couldn&apos;t write to the process</source>
-        <translation>prosese yaz&#305;lam&#305;yor</translation>
+        <translation>prosese yazılamıyor</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="78"/>
         <source>an unknown error occurred</source>
-        <translation>bilinmeyen bir hata olu&#351;tu</translation>
+        <translation>bilinmeyen bir hata oluştu</translation>
     </message>
 </context>
 <context>
@@ -4027,7 +4027,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/projectmanager.cpp" line="119"/>
         <source>Import Directory &lt;%1&gt;</source>
-        <translation>&#304;&#231;e Aktar&#305;m Dizini &lt;%1&gt;</translation>
+        <translation>İçe Aktarım Dizini &lt;%1&gt;</translation>
     </message>
 </context>
 <context>
@@ -4076,7 +4076,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="82"/>
         <source>Stop Search</source>
-        <translation>Aramay&#305; Durdur</translation>
+        <translation>Aramayı Durdur</translation>
     </message>
 </context>
 <context>
@@ -4084,7 +4084,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="14"/>
         <source>Debug External Application</source>
-        <translation>Harici Uygulamada Hata Ay&#305;kla</translation>
+        <translation>Harici Uygulamada Hata Ayıkla</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="22"/>
@@ -4106,18 +4106,18 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="46"/>
         <source>Working directory:</source>
-        <translation>&#199;al&#351;ma dizini:</translation>
+        <translation>Çalşma dizini:</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.cpp" line="82"/>
         <source>Select Executable</source>
-        <translation>&#199;al&#305;&#351;t&#305;rlabilir Dosya Se&#231;in</translation>
+        <translation>Çalıştırlabilir Dosya Seçin</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.cpp" line="92"/>
         <source>Select the working directory:</source>
         <oldsource>Select Working Directory</oldsource>
-        <translation>&#199;al&#305;&#351;ma dizinini se&#231;in:</translation>
+        <translation>Çalışma dizinini seçin:</translation>
     </message>
 </context>
 <context>
@@ -4125,12 +4125,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="14"/>
         <source>Manage GOPATH</source>
-        <translation>GOPATH&apos;&#305; Yönet</translation>
+        <translation>GOPATH&apos;ı Yönet</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="20"/>
         <source>System GOPATH</source>
-        <translation>Sistemde Kay&#305;tl&#305; GOPATH</translation>
+        <translation>Sistemde Kayıtlı GOPATH</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="35"/>
@@ -4140,7 +4140,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="60"/>
         <source>Custom Directories (one per line)</source>
-        <translation>Özel Dizinler (sat&#305;r ba&#351;&#305;na bir tane)</translation>
+        <translation>Özel Dizinler (satır başına bir tane)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="71"/>
@@ -4156,7 +4156,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/golangpackage/setupgopathdialog.cpp" line="74"/>
         <source>Choose directory to add to GOPATH:</source>
         <oldsource>Load GOPATH Directory</oldsource>
-        <translation>GOPATH'e eklemek i&#231;in dizin se&#231;in:</translation>
+        <translation>GOPATH'e eklemek için dizin seçin:</translation>
     </message>
 </context>
 <context>
@@ -4169,7 +4169,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/sidewindowstyle.cpp" line="59"/>
         <source>Show SideBar</source>
-        <translation>Sidebar&apos;&#305; Göster</translation>
+        <translation>Sidebar&apos;ı Göster</translation>
     </message>
 </context>
 <context>
@@ -4177,7 +4177,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/sidewindowstyle.cpp" line="428"/>
         <source>Hide SideBar</source>
-        <translation>Sidebar&apos;&#305; Gizle</translation>
+        <translation>Sidebar&apos;ı Gizle</translation>
     </message>
     <message>
         <location filename="src/liteapp/sidewindowstyle.cpp" line="461"/>
@@ -4187,7 +4187,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/sidewindowstyle.cpp" line="462"/>
         <source>Output Windows</source>
-        <translation>&#199;&#305;kt&#305; Pencereleri</translation>
+        <translation>Çıktı Pencereleri</translation>
     </message>
 </context>
 <context>
@@ -4197,7 +4197,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/liteapp/tooldockwidget.cpp" line="267"/>
         <location filename="src/liteapp/tooldockwidget.cpp" line="268"/>
         <source>Move To</source>
-        <translation>&#350;uraya Ta&#351;&#305;</translation>
+        <translation>Şuraya Taşı</translation>
     </message>
     <message>
         <location filename="src/liteapp/tooldockwidget.cpp" line="201"/>
@@ -4232,17 +4232,17 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/tooldockwidget.cpp" line="231"/>
         <source>Right</source>
-        <translation>Sa&#287;a</translation>
+        <translation>Sağa</translation>
     </message>
     <message>
         <location filename="src/liteapp/tooldockwidget.cpp" line="235"/>
         <source>Right (Split)</source>
-        <translation>Sa&#287;a (Böl)</translation>
+        <translation>Sağa (Böl)</translation>
     </message>
     <message>
         <location filename="src/liteapp/tooldockwidget.cpp" line="243"/>
         <source>Unsplit</source>
-        <translation>Birle&#351;tir</translation>
+        <translation>Birleştir</translation>
     </message>
     <message>
         <location filename="src/liteapp/tooldockwidget.cpp" line="248"/>
@@ -4255,12 +4255,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/splitwindowstyle.cpp" line="242"/>
         <source>Hide Sidebars</source>
-        <translation>Sidebar&apos;lar&#305; Gizle</translation>
+        <translation>Sidebar&apos;ları Gizle</translation>
     </message>
     <message>
         <location filename="src/liteapp/splitwindowstyle.cpp" line="275"/>
         <source>Tool Windows</source>
-        <translation>Ara&#231; Pencereleri</translation>
+        <translation>Araç Pencereleri</translation>
     </message>
 </context>
 <context>
@@ -4278,12 +4278,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/utils/textoutput/terminaledit.cpp" line="66"/>
         <source>Paste</source>
-        <translation>Yap&#305;&#351;t&#305;r</translation>
+        <translation>Yapıştır</translation>
     </message>
     <message>
         <location filename="src/utils/textoutput/terminaledit.cpp" line="69"/>
         <source>Select All</source>
-        <translation>Tümünü Se&#231;</translation>
+        <translation>Tümünü Seç</translation>
     </message>
     <message>
         <location filename="src/utils/textoutput/terminaledit.cpp" line="72"/>
@@ -4296,7 +4296,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/3rdparty/qtc_texteditor/colorscheme.cpp" line="212"/>
         <source>Not a color scheme file.</source>
-        <translation>Ge&#231;erli bir renk &#351;ema dosyas&#305; de&#287;il.</translation>
+        <translation>Geçerli bir renk şema dosyası değil.</translation>
     </message>
 </context>
 <context>
@@ -4323,12 +4323,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="72"/>
         <source>Open Html File</source>
         <oldsource>Open Html</oldsource>
-        <translation>HTML Dosyas&#305; A&#231;</translation>
+        <translation>HTML Dosyası Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="119"/>
         <source>WebKitBrowser</source>
-        <translation>WebKit Tabanl&#305; Taray&#305;c&#305;</translation>
+        <translation>WebKit Tabanlı Tarayıcı</translation>
     </message>
     <message>
         <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="169"/>
@@ -4339,7 +4339,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="256"/>
         <source>Open Html or Markdown File</source>
         <oldsource>Open Html or Markdown Files</oldsource>
-        <translation>HTML veya Markdown Dosyas&#305; A&#231;</translation>
+        <translation>HTML veya Markdown Dosyası Aç</translation>
     </message>
 </context>
 <context>
@@ -4348,7 +4348,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/webkithtmlwidget/webkithtmlwidgetplugin.cpp" line="74"/>
         <source>Open Html or Markdown File</source>
         <oldsource>Open Html or Markdown Files</oldsource>
-        <translation>HTML veya Markdown Dosyas&#305; A&#231;</translation>
+        <translation>HTML veya Markdown Dosyası Aç</translation>
     </message>
 </context>
 <context>
@@ -4361,12 +4361,12 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/welcome/welcomebrowser.cpp" line="66"/>
         <source>Open</source>
-        <translation>A&#231;</translation>
+        <translation>Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/welcome/welcomebrowser.cpp" line="67"/>
         <source>Open Folder</source>
-        <translation>Dizin A&#231;</translation>
+        <translation>Dizin Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/welcome/welcomebrowser.cpp" line="68"/>
@@ -4377,7 +4377,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/welcome/welcomebrowser.cpp" line="216"/>
         <source>Welcome</source>
         <oldsource>Welcome Page</oldsource>
-        <translation>Ho&#351;geldiniz</translation>
+        <translation>Hoşgeldiniz</translation>
     </message>
 </context>
 <context>
@@ -4386,7 +4386,7 @@ De&#287;i&#351;tirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/welcome/welcomeplugin.cpp" line="71"/>
         <source>Welcome</source>
         <oldsource>Home</oldsource>
-        <translation>Ho&#351;geldiniz</translation>
+        <translation>Hoşgeldiniz</translation>
     </message>
 </context>
 </TS>

--- a/liteidex/liteide_tr.ts
+++ b/liteidex/liteide_tr.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="tr_TR">
+<TS version="2.1" language="tr_TR">
 <context>
     <name>AboutDialog</name>
     <message>
@@ -25,7 +25,7 @@
         <source>Welcome to LiteIDE X! LiteIDE is a simple, open source, cross-platform IDE.</source>
         <oldsource>Welcome to LiteIDE X!
 LiteIDE is a simple, open source, cross-platform IDE.</oldsource>
-        <translation>LiteIDE X'e hoşgeldiniz!
+        <translation>LiteIDE X&apos;e hoşgeldiniz!
 LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıdır.</translation>
     </message>
     <message>
@@ -46,7 +46,7 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="222"/>
         <source>Version:</source>
-        <translation>Sürüm:</translation>
+        <translation>Versiyon:</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="242"/>
@@ -68,7 +68,7 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
         <location filename="src/liteapp/aboutdialog.ui" line="263"/>
         <source>Support LiteIDE:</source>
         <oldsource>Support</oldsource>
-        <translation>LiteIDE'yi destekle:</translation>
+        <translation>LiteIDE&apos;yi destekle::</translation>
     </message>
     <message>
         <location filename="src/liteapp/aboutdialog.ui" line="297"/>
@@ -116,17 +116,17 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
         <translation>Ukraynaca</translation>
     </message>
     <message>
-        <location filename="src/liteapp/aboutdialog.ui" line="537"/>
+        <location filename="src/liteapp/aboutdialog.ui" line="544"/>
         <source>Thanks to...</source>
         <translation>Teşekkürler...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/aboutdialog.ui" line="572"/>
+        <location filename="src/liteapp/aboutdialog.ui" line="577"/>
         <source>License</source>
         <translation>Lisans</translation>
     </message>
     <message>
-        <location filename="src/liteapp/aboutdialog.ui" line="613"/>
+        <location filename="src/liteapp/aboutdialog.ui" line="619"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
@@ -139,239 +139,379 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
 <context>
     <name>ActionManager</name>
     <message>
-        <location filename="src/liteapp/actionmanager.cpp" line="64"/>
+        <location filename="src/liteapp/actionmanager.cpp" line="65"/>
         <source>&amp;File</source>
         <translation>&amp;Dosya</translation>
     </message>
     <message>
-        <location filename="src/liteapp/actionmanager.cpp" line="65"/>
+        <location filename="src/liteapp/actionmanager.cpp" line="66"/>
         <source>&amp;Recent</source>
-        <translatorcomment>Note to the Developer: This shoud be a sub menu of &quot;File&quot;</translatorcomment>
         <translation>&amp;Son kullanılanlar</translation>
     </message>
     <message>
-        <location filename="src/liteapp/actionmanager.cpp" line="66"/>
-        <source>&amp;Edit</source>
-        <translation>&amp;Düzen</translation>
-    </message>
-    <message>
         <location filename="src/liteapp/actionmanager.cpp" line="67"/>
-        <source>F&amp;ind</source>
-        <oldsource>&amp;Find</oldsource>
-        <translation>&amp;Bul</translation>
+        <source>&amp;Edit</source>
+        <translation>Düzen&amp;le</translation>
     </message>
     <message>
         <location filename="src/liteapp/actionmanager.cpp" line="68"/>
-        <source>&amp;View</source>
-        <translation>&amp;Görünüm</translation>
+        <source>F&amp;ind</source>
+        <oldsource>&amp;Find</oldsource>
+        <translation>&amp;Ara</translation>
     </message>
     <message>
-        <location filename="src/liteapp/actionmanager.cpp" line="73"/>
+        <location filename="src/liteapp/actionmanager.cpp" line="69"/>
+        <source>&amp;View</source>
+        <translation>&amp;Göster</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/actionmanager.cpp" line="74"/>
+        <source>&amp;Tools</source>
+        <translation>A&amp;raçlar</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/actionmanager.cpp" line="75"/>
+        <source>&amp;Build</source>
+        <translation>&amp;Derle</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/actionmanager.cpp" line="76"/>
+        <source>&amp;Debug</source>
+        <translation>&amp;Hata Ayıklama</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/actionmanager.cpp" line="77"/>
         <source>&amp;Help</source>
         <translation>&amp;Yardım</translation>
     </message>
     <message>
-        <location filename="src/liteapp/actionmanager.cpp" line="75"/>
+        <location filename="src/liteapp/actionmanager.cpp" line="79"/>
         <source>Standard Toolbar</source>
         <oldsource>Standard ToolBar</oldsource>
-        <translation>Standart araç çubuğu</translation>
+        <translation>Standart Araç Çubuğu</translation>
     </message>
 </context>
 <context>
     <name>AstWidget</name>
     <message>
-        <location filename="src/plugins/golangast/astwidget.cpp" line="75"/>
+        <location filename="src/plugins/golangast/astwidget.cpp" line="76"/>
         <source>Go To Definition</source>
         <translation>Tanımlamaya Git</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangast/astwidget.cpp" line="76"/>
+        <location filename="src/plugins/golangast/astwidget.cpp" line="77"/>
         <source>View Import Document</source>
-        <translation>İçeri aktarma görünümü</translation>
+        <translation>İçeri Aktarma Görünümü</translation>
     </message>
 </context>
 <context>
     <name>BaseDockWidget</name>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="63"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="77"/>
         <source>Hide</source>
         <translation>Gizle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="64"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="78"/>
         <source>Hide Tool Window</source>
-        <translation type="unfinished">Araç Penceresini Gizle</translation>
+        <translation>Araç Penceresini Gizle</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="87"/>
+        <source>Floating Window</source>
+        <translation>Sabit Olmayan Pencere</translation>
     </message>
 </context>
 <context>
     <name>BaseFolderView</name>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="72"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="77"/>
+        <source>Open In New Window</source>
+        <translation>Yeni Pencerede Aç</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="78"/>
         <source>Open File</source>
         <translation>Dosya Aç</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="73"/>
-        <source>New File...</source>
-        <translation type="unfinished">Yeni Dosya...</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="74"/>
-        <source>New File Wizard...</source>
-        <translation type="unfinished">Yeni Dosya Sihirbazı...</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="75"/>
-        <source>Rename File...</source>
-        <translation>Dosya adını değiştir...</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="76"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="209"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="215"/>
-        <source>Delete File</source>
-        <translation type="unfinished">Dosyayı sil</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="78"/>
-        <source>New Folder...</source>
-        <translation type="unfinished">Yeni Dizin...</translation>
-    </message>
-    <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="79"/>
-        <source>Rename Folder...</source>
-        <translation type="unfinished">Dizini yeniden adlandır...</translation>
+        <source>New File...</source>
+        <translation>Yeni Dosya...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="80"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="279"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="286"/>
-        <source>Delete Folder</source>
-        <translation type="unfinished">Dizini sil</translation>
+        <source>New File Wizard...</source>
+        <translation>Yeni Dosya Sihirbazı...</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="81"/>
+        <source>Rename File...</source>
+        <translation>Dosya Adı Değiştir...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="82"/>
-        <source>Open Terminal Here</source>
-        <translation>Burada komut satırı aç</translation>
+        <source>Delete File</source>
+        <translation>Dosya Sil</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="83"/>
-        <source>Open Explorer Here</source>
-        <translation>Bulunduğu dizini aç</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="84"/>
+        <source>New Folder...</source>
+        <translation>Yeni Klasör...</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="85"/>
-        <source>Use godoc View</source>
-        <translation>Godoc görünümünü kullan</translation>
+        <source>Rename Folder...</source>
+        <translation>Klasör Adı Değiştir...</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="87"/>
-        <source>Open Folder...</source>
-        <oldsource>Add Folder...</oldsource>
-        <translation type="unfinished">Dizin Aç...</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="86"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="328"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="335"/>
+        <source>Delete Folder</source>
+        <translation>Klasör Sil</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="88"/>
-        <source>Reload Folder</source>
-        <translation>Dizini Yenile</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="99"/>
+        <source>Open Terminal Here</source>
+        <translation>Burada Terminal Aç</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="89"/>
-        <source>Close Folder</source>
-        <translation type="unfinished">Dizini Kapat</translation>
+        <source>Show in Explorer</source>
+        <oldsource>Open Explorer Here</oldsource>
+        <translation>Explorer ile Aç</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="76"/>
+        <source>Open Application</source>
+        <translation>Uygulamayı Aç</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="91"/>
+        <source>Show in Finder</source>
+        <translation>Finder ile Aç</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="93"/>
+        <source>Show Containing Folder</source>
+        <translation>İçeren Klasörü Göster</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="97"/>
+        <source>Open Command Prompt Here</source>
+        <translation>Burada Komut Satırını Aç</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="102"/>
+        <source>Open Folder...</source>
+        <oldsource>Add Folder...</oldsource>
+        <translation>Klasör Aç...</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="103"/>
+        <source>Reload Folder</source>
+        <translation>Klasörü Tekrar Yükle</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="104"/>
+        <source>Close Folder</source>
+        <translation>Klasörü Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="106"/>
         <source>Close All Folders</source>
-        <translation>Tüm Dizinleri Kapat</translation>
+        <translation>Bütük Klasörleri Kapat</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="143"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="153"/>
-        <source>Create File</source>
-        <translation type="unfinished">Dosya Oluştur</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="108"/>
+        <source>Copy</source>
+        <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="144"/>
-        <source>A file with that name already exists!</source>
-        <translation>Bu isimde bir dosya zaten var!</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="109"/>
+        <source>Paste</source>
+        <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="154"/>
-        <source>Failed to create the file!</source>
-        <translation>Dosya yaratılamadı!</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="184"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="190"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="195"/>
-        <source>Rename File</source>
-        <translation type="unfinished">Dosya İsmini Değiştir</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="184"/>
-        <source>New Name:</source>
-        <translation type="unfinished">Yeni İsim:</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="110"/>
+        <source>Move To Trash</source>
+        <translation>Çöp Kutusuna Taşı</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="191"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="196"/>
-        <source>Failed to rename the file!</source>
-        <translation type="unfinished">Dosya ismi değiştirilemedi!</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="201"/>
+        <source>Create File</source>
+        <translation>Dosya Oluştur</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="210"/>
-        <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bu dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="192"/>
+        <source>A file with that name already exists!</source>
+        <translation>Bu İsimde Dosya Mevcut!</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="216"/>
-        <source>Failed to delete the file!</source>
-        <translation>Dosya silinemiyor!</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="202"/>
+        <source>Failed to create the file!</source>
+        <translation>Dosya Oluşturulamadı!</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="234"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="237"/>
-        <source>Create Folder</source>
-        <translation>Dizin Oluştur</translation>
-    </message>
-    <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="235"/>
-        <source>A folder with that name already exists!</source>
-        <translation >Bu isimde bir dizin zaten mevcut!</translation>
-    </message>
-    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="232"/>
         <location filename="src/utils/folderview/basefolderview.cpp" line="238"/>
-        <source>Failed to create the folder!</source>
-        <translation>Dizin yaratılamıyor!</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="243"/>
+        <source>Rename File</source>
+        <translation>Dosya Adını Değiştir</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="251"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="260"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="265"/>
-        <source>Rename Folder</source>
-        <translation>Dizini Yeniden Adlandır</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="232"/>
+        <source>New Name:</source>
+        <translation>Yrni İsim:</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="251"/>
-        <source>Folder Name</source>
-        <translation>Dizin Adı</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="239"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="244"/>
+        <source>Failed to rename the file!</source>
+        <translation>İsim Değiştirilemedi!</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="261"/>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="266"/>
-        <source>Failed to rename the folder!</source>
-        <translation>Dizin adı değiştirilemiyor!</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="489"/>
+        <source>An item &quot;%1&quot; already exists in this location. Do you want to replace it and move old item to trash?</source>
+        <translation>&quot;%1&quot; burada zaten var. Eski dosyanın üzerine yazmak istermisiniz?</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/basefolderview.cpp" line="280"/>
-        <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="490"/>
+        <source>Stop</source>
+        <translation>Dur</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="491"/>
+        <source>Keep Both</source>
+        <translation>İkisini de Koru</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="492"/>
+        <source>Keep Both All</source>
+        <translation>Her İkisini de Koru</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="493"/>
+        <source>Replace</source>
+        <translation>Üzerine Yaz</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="494"/>
+        <source>Replace All</source>
+        <translation>Hepsinin Üzerine Yaz</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="579"/>
+        <source>Are you sure that you want move to trash this item?</source>
+        <translation>Bu öğeyi çöp kutusuna taşımak istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="582"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="585"/>
+        <source>Are you sure that you want move to trash %1 items?</source>
+        <translation>%1 öğeyi çöp kutusuna taşımak istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="588"/>
+        <source>Move to Trash</source>
+        <translation>Çöp Kutusuna Taşı</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="632"/>
+        <source>Open With</source>
+        <translation>Birlikte Aç</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="639"/>
+        <source>System Editor</source>
+        <translation>Sistem Editörü</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="283"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="286"/>
+        <source>Create Folder</source>
+        <translation>Klasör Oluştur</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="284"/>
+        <source>A folder with that name already exists!</source>
+        <translation>Bu isimde bir klasör zaten var!</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/basefolderview.cpp" line="287"/>
+        <source>Failed to create the folder!</source>
+        <translation>Klasör Oluşturulamadı!</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="300"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="309"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="314"/>
+        <source>Rename Folder</source>
+        <translation>Klasör Adını Değiştir</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="300"/>
+        <source>Folder Name</source>
+        <translation>Klasö Adı</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="310"/>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="315"/>
+        <source>Failed to rename the folder!</source>
+        <translation>Klasör Adı Değiştirilemedi!</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="329"/>
+        <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
+        <translation>Bu klasörü ve tüm içeriğini kalıcı olarak silmek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/basefolderview.cpp" line="336"/>
         <source>Failed to delete the folder!</source>
-        <translation>Dizin silinemiyor!</translation>
+        <translation>Klasör Silinemedi!</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkManager</name>
+    <message>
+        <location filename="src/plugins/bookmarks/bookmarkmanager.cpp" line="61"/>
+        <source>Toggle Bookmark</source>
+        <translation>Yer İşaretini Değiştir</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/bookmarks/bookmarkmanager.cpp" line="96"/>
+        <source>Goto bookmark</source>
+        <translation>Yer İşaretine Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/bookmarks/bookmarkmanager.cpp" line="97"/>
+        <source>Remove bookmark</source>
+        <translation>Yer İşaretini Sil</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/bookmarks/bookmarkmanager.cpp" line="98"/>
+        <source>Remove all bookmarks for this file</source>
+        <translation>Bu dosya için tüm yer işaretlerini kaldırın</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/bookmarks/bookmarkmanager.cpp" line="99"/>
+        <source>Remove all bookmarks for all files</source>
+        <translation>Bütün dosyalar için tüm yer işaretlerini kaldırın</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/bookmarks/bookmarkmanager.cpp" line="115"/>
+        <source>Bookmarks</source>
+        <translation>Yer imleri</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarkRecent</name>
+    <message>
+        <location filename="src/liteapp/recentmanager.h" line="81"/>
+        <source>Bookmarks</source>
+        <translation>Yer imleri</translation>
     </message>
 </context>
 <context>
@@ -380,35 +520,118 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
         <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="14"/>
         <source>Build Configuration</source>
         <oldsource>Build Config Dialog</oldsource>
-        <translation>Build Ayarları</translation>
+        <translation>Derleme Ayarları</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="26"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="71"/>
         <source>Build ID</source>
-        <translation>Build ID</translation>
+        <translation>Derleme ID</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="52"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="45"/>
         <source>Build Path</source>
         <oldsource>Build File</oldsource>
-        <translation>Build Yolu</translation>
+        <translation>Derleme Yolu</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="85"/>
+        <source>GOPATH</source>
+        <translation>GOPATH</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="103"/>
+        <source>GOPATH information</source>
+        <translation>GOPATH bilgisi</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="147"/>
+        <source>Use Custom GOPATH for Build Path</source>
+        <translation>Derleme Yolu için Özel GOPATH Kullanın</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="159"/>
+        <source>Inherit System GOPATH</source>
+        <translation>Sistem&apos;de Tanımlı GOPATH</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="179"/>
+        <source>Inherit LiteIDE GOPATH</source>
+        <translation>LiteIDE&apos;de Tanımlı GOPAT</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="201"/>
+        <source>Custom GOPATH (one per line)</source>
+        <translation>Özel GOPATH (satır başına bir)</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="221"/>
+        <source>Add Directory...</source>
+        <translation>Klasör Ekle...</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="228"/>
+        <source>Clear</source>
+        <translation>Temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="244"/>
         <source>LiteIDE</source>
         <translation>LiteIDE</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="95"/>
-        <source>Build</source>
-        <oldsource>Build Config</oldsource>
-        <translation>Build</translation>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="266"/>
+        <source>Config</source>
+        <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="105"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="288"/>
+        <source>Action</source>
+        <translation>Eylem</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="310"/>
         <source>Custom</source>
         <oldsource>Build Custom</oldsource>
-        <translation>Özel</translation>
+        <translation>Özel Derleme</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.ui" line="343"/>
+        <source>Reset all to initial value</source>
+        <translation>Tümünü başlangıç değerine sıfırla</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="69"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="73"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="77"/>
+        <source>Name</source>
+        <translation>İsim</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="70"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="74"/>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="78"/>
+        <source>Value</source>
+        <translation>Değer</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="79"/>
+        <source>SharedValue</source>
+        <translation>Paylaşımlı Değer</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="82"/>
+        <source>Id</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="83"/>
+        <source>Cmd</source>
+        <translation>Cmd</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/buildconfigdialog.cpp" line="293"/>
+        <source>Choose directory to add to GOPATH:</source>
+        <translation>GOPATH&apos;a eklenecek dizini seçin:</translation>
     </message>
 </context>
 <context>
@@ -416,17 +639,17 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="94"/>
         <source>Create Folder</source>
-        <translation>Dizin Oluştur</translation>
+        <translation>Klasör Oluştur</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="96"/>
         <source>Directory:</source>
-        <translation>Dizin:</translation>
+        <translation>Klasör:</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="98"/>
         <source>Dir Name:</source>
-        <translation>Dizin Adı:</translation>
+        <translation>Klasör Adı:</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="106"/>
@@ -436,7 +659,7 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="107"/>
         <source>Cancel</source>
-        <translation>Vazgeç</translation>
+        <translation>İptal</translation>
     </message>
 </context>
 <context>
@@ -450,7 +673,7 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="46"/>
         <source>Directory:</source>
-        <translation>Dizin:</translation>
+        <translation>Klasör:</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="48"/>
@@ -465,209 +688,248 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="57"/>
         <source>Create and Edit</source>
-        <translation>Oluşutur ve Düzenle</translation>
+        <translation>Oluştur ve Düzenle</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/folderdialog.cpp" line="58"/>
         <source>Cancel</source>
-        <translation>Vazgeç</translation>
+        <translation>İptal</translation>
     </message>
 </context>
 <context>
     <name>DebugWidget</name>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="80"/>
-        <source>Async Record</source>
-        <oldsource>AsyncRecord</oldsource>
-        <translation>Asenkron Kayıt</translation>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="122"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="321"/>
+        <source>Add Watch</source>
+        <translation>İzleyici Ekle</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="81"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="221"/>
+        <source>Async Record</source>
+        <oldsource>AsyncRecord</oldsource>
+        <translation>Eşzamansız Kayıt</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="222"/>
         <source>Variables</source>
         <translation>Değişkenler</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="82"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="223"/>
         <source>Watch</source>
         <translation>İzle</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="83"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="224"/>
         <source>Call Stack</source>
         <oldsource>CallStack</oldsource>
-        <translation>Çağrı Yığını</translation>
+        <translation>Yığın Çağrıları</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="84"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="225"/>
+        <source>Threads</source>
+        <translation>İş Parçacığı</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="226"/>
+        <source>Goroutines</source>
+        <translation>Goroutines</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="227"/>
+        <source>Registers</source>
+        <translation>Registers</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="228"/>
         <source>Libraries</source>
         <oldsource>Library</oldsource>
-        <translation>Kütüphaneler</translation>
+        <translation>Kitaplık</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="85"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="229"/>
         <source>Console</source>
         <translation>Konsol</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="94"/>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="259"/>
-        <source>Add Global Watch</source>
-        <translation>Genel İzlemeye Al</translation>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="321"/>
+        <source>Watch expression (e.g. buf main.var os.Stdout):</source>
+        <translation>İfadeyi izle (ör. Buf main.var os.Stdout):</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="95"/>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="271"/>
-        <source>Add Local Watch</source>
-        <translation>Lokal İzlemeye Al</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="96"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="124"/>
         <source>Remove Watch</source>
-        <translation>İzlemeden Kaldır</translation>
+        <translation>İzleyiciyi Sil</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="97"/>
+        <location filename="src/plugins/litedebug/debugwidget.cpp" line="125"/>
         <source>Remove All Watches</source>
-        <translation>Tüm İzlemeleri Kaldır</translation>
+        <translation>Bütün İzleyicileri Sil</translation>
     </message>
+</context>
+<context>
+    <name>DlvDebuggerOption</name>
     <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="259"/>
-        <source>Watch expression (e.g. main.var os.Stdout):</source>
-        <translation>Sözdizimini izle (örn: main.var, os.Stdout):</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litedebug/debugwidget.cpp" line="271"/>
-        <source>Watch expression (e.g. s1.str):</source>
-        <translation>Sözdizimini izle (örn: s1.str):</translation>
+        <location filename="src/plugins/dlvdebugger/dlvdebuggeroption.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
     </message>
 </context>
 <context>
     <name>DocumentBrowser</name>
     <message>
-        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="67"/>
+        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="68"/>
         <source>Back</source>
         <oldsource>Backward</oldsource>
         <translation>Geri</translation>
     </message>
     <message>
-        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="68"/>
+        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="69"/>
         <source>Forward</source>
         <translation>İleri</translation>
     </message>
     <message>
-        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="69"/>
+        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="70"/>
         <source>Reload</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="75"/>
+        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="76"/>
         <source>Increase Font Size</source>
-        <translation>Yazıtipini Büyüt</translation>
+        <translation>Font Büyüklüğünü Arttır</translation>
     </message>
     <message>
-        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="78"/>
+        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="79"/>
         <source>Decrease Font Size</source>
-        <translation>Yazıtipini Küçült</translation>
+        <translation>Font Büyüklüğünü Azalt</translation>
     </message>
     <message>
-        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="81"/>
+        <location filename="src/utils/documentbrowser/documentbrowser.cpp" line="82"/>
         <source>Reset Font Size</source>
-        <translation>Yazıtipi Boyutunu Sıfırla</translation>
+        <translation>Font Büyüklüğünü Sıfırla</translation>
+    </message>
+</context>
+<context>
+    <name>DocumentBrowserFactory</name>
+    <message>
+        <location filename="src/utils/documentbrowser/documentbrowserfactory.cpp" line="67"/>
+        <source>DocumentBrowser</source>
+        <translation>Belge Tarayıcı</translation>
     </message>
 </context>
 <context>
     <name>EditorManager</name>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="114"/>
+        <location filename="src/liteapp/editormanager.cpp" line="138"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="125"/>
+        <location filename="src/liteapp/editormanager.cpp" line="163"/>
         <source>Move to New Window</source>
         <oldsource>Move To New Window</oldsource>
         <translation>Yeni Pencereye Taşı</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="171"/>
-        <source>&amp;Edit</source>
-        <oldsource>Edit</oldsource>
-        <translation>Düzen</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/editormanager.cpp" line="185"/>
+        <location filename="src/liteapp/editormanager.cpp" line="229"/>
         <source>Navigate Forward</source>
         <oldsource>GoForward</oldsource>
-        <translation>İleri Git</translation>
+        <translation>İlerle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="116"/>
+        <location filename="src/liteapp/editormanager.cpp" line="140"/>
         <source>Close Others</source>
         <oldsource>Close Others Tabs</oldsource>
         <translation>Diğerlerini Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="117"/>
+        <location filename="src/liteapp/editormanager.cpp" line="110"/>
+        <source>Open Editor</source>
+        <translation>Editör Aç</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/editormanager.cpp" line="141"/>
         <source>Close All</source>
         <oldsource>Close All Tabs</oldsource>
-        <translation>Tümünü Kapat</translation>
+        <translation>Hepsini Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="118"/>
+        <location filename="src/liteapp/editormanager.cpp" line="142"/>
         <source>Close Left Tabs</source>
-        <translation>Soldaki Sekmeleri Kapat</translation>
+        <translation>Soldaki Tabları Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="119"/>
+        <location filename="src/liteapp/editormanager.cpp" line="143"/>
         <source>Close Right Tabs</source>
-        <translation>Sağdaki Sekmeleri Kapat</translation>
+        <translation>Sağdaki Tabları Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="120"/>
+        <location filename="src/liteapp/editormanager.cpp" line="144"/>
         <source>Close Files in Same Folder</source>
         <oldsource>Close Same Folder Files</oldsource>
-        <translation>Aynı Dizindeki Dosyaları Kapat</translation>
+        <translation>Aynı Klasördeki Dosyaları Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="121"/>
+        <location filename="src/liteapp/editormanager.cpp" line="145"/>
         <source>Close Files in Other Folders</source>
         <oldsource>Close Other Folder Files</oldsource>
-        <translation>Diğer Dizinlerdeki Dosyaları Kapat</translation>
+        <translation>Diğer Klasörlerdeki Dosyaları Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="122"/>
+        <location filename="src/liteapp/editormanager.cpp" line="146"/>
         <source>Copy Full Path to Clipboard</source>
         <oldsource>Copy Path to Clipboard</oldsource>
-        <translation>Dosya Yolunu Kopyala</translation>
+        <translation>Tam Yolu Panoya Kopyala</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="123"/>
+        <location filename="src/liteapp/editormanager.cpp" line="149"/>
         <source>Show in Explorer</source>
-        <translation>Dizinde Göster</translation>
+        <translation>Explorer&apos;de Göster</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="176"/>
+        <location filename="src/liteapp/editormanager.cpp" line="151"/>
+        <source>Show in Finder</source>
+        <translation>Finder&apos;de Göster</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/editormanager.cpp" line="153"/>
+        <source>Show Containing Folder</source>
+        <translation>İçeren Klasörü Göster</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/editormanager.cpp" line="157"/>
+        <source>Open Command Prompt Here</source>
+        <translation>Komut İstemi&apos;ni Burada Açın</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/editormanager.cpp" line="159"/>
+        <source>Open Terminal Here</source>
+        <translation>Terminal&apos;i Burada Açın</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/editormanager.cpp" line="220"/>
         <source>Navigate Backward</source>
         <translation>Geri Git</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="364"/>
+        <location filename="src/liteapp/editormanager.cpp" line="422"/>
         <source>Save changes to %1?</source>
-        <translation>Değişikler %1 içine kaydedilsin mi?</translation>
+        <translation>%1&apos;deki değişiklikler kaydedilsin mi?</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="365"/>
+        <location filename="src/liteapp/editormanager.cpp" line="423"/>
         <source>Unsaved Modifications</source>
         <oldsource>Save Modify</oldsource>
         <translation>Kaydedilmemiş Değişiklikler</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="447"/>
+        <location filename="src/liteapp/editormanager.cpp" line="520"/>
         <source>All Files (*)</source>
         <translation>Tüm Dosyalar (*)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/editormanager.cpp" line="449"/>
+        <location filename="src/liteapp/editormanager.cpp" line="522"/>
         <source>Save As</source>
         <translation>Farklı Kaydet</translation>
     </message>
@@ -675,28 +937,33 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
 <context>
     <name>EnvManager</name>
     <message>
-        <location filename="src/plugins/liteenv/envmanager.cpp" line="358"/>
+        <location filename="src/plugins/liteenv/envmanager.cpp" line="436"/>
         <source>Environment Toolbar</source>
         <oldsource>Environment ToolBar</oldsource>
-        <translation>ÇAlışma ortamı Araç Çubuğu</translation>
+        <translation>Ortam Araç Çubuğu</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteenv/envmanager.cpp" line="365"/>
+        <location filename="src/plugins/liteenv/envmanager.cpp" line="443"/>
         <source>Switching current environment</source>
         <oldsource>Switch Current Environment</oldsource>
-        <translation>Çalışma ortamı değiştiriliyor</translation>
+        <translation>Mevcut ortamı değiştirme</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteenv/envmanager.cpp" line="368"/>
+        <location filename="src/plugins/liteenv/envmanager.cpp" line="446"/>
         <source>Edit current environment</source>
         <oldsource>Edit Current Environment</oldsource>
-        <translation>Çalışma ortamını düzenle</translation>
+        <translation>Mevcut ortamı değiştir</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteenv/envmanager.cpp" line="369"/>
+        <location filename="src/plugins/liteenv/envmanager.cpp" line="447"/>
         <source>Reload current environment</source>
         <oldsource>Reload Current Environment</oldsource>
-        <translation>Çalışma ortamını yenile</translation>
+        <translation>Mevcut ortamı yeniden yükle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteenv/envmanager.cpp" line="451"/>
+        <source>Select Environment</source>
+        <translation>Ortam Seç</translation>
     </message>
 </context>
 <context>
@@ -704,7 +971,7 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation>Dışa Aktar</translation>
+        <translation>Diyalog</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="22"/>
@@ -719,7 +986,233 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/plugins/golangpresent/exportdialog.ui" line="56"/>
         <source>ExportAndView</source>
-        <translation>Dışa Aktar ve Görüntüle</translation>
+        <translation>Dışa Aktar ve İncele</translation>
+    </message>
+</context>
+<context>
+    <name>FakeVim::Internal</name>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimactions.cpp" line="194"/>
+        <source>Use Vim-style Editing</source>
+        <translation>Vim Tarzı Editör Kullan</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimactions.cpp" line="196"/>
+        <source>Read .vimrc</source>
+        <translation>.vimrc Oku</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimactions.cpp" line="198"/>
+        <source>Path to .vimrc</source>
+        <translation>.vimrc Yolu</translation>
+    </message>
+</context>
+<context>
+    <name>FakeVim::Internal::FakeVimHandler</name>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimactions.cpp" line="153"/>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimactions.cpp" line="161"/>
+        <source>Unknown option: %1</source>
+        <translation>Bilinmeyen seçenek:%1</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimactions.cpp" line="156"/>
+        <source>Argument must be positive: %1=%2</source>
+        <translation>Argüman pozitif olmalıdır:%1=%2</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="949"/>
+        <source>Mark &quot;%1&quot; not set.</source>
+        <translation>&quot;%1&quot; işareti ayarlanmadı.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="3538"/>
+        <source>%1%2%</source>
+        <translation>%1%2%</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="3540"/>
+        <source>%1All</source>
+        <translation>%1 Hespsi</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="3554"/>
+        <source>Not implemented in FakeVim.</source>
+        <translation>FakeVim&apos;de uygulanmaz.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5719"/>
+        <source>Unknown option:</source>
+        <translation>Bilinmeyen seçenek:</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5730"/>
+        <source>Invalid argument:</source>
+        <translation>Geçersiz argüman:</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5733"/>
+        <source>Trailing characters:</source>
+        <translation>Sondaki karakterler:</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5816"/>
+        <source>Move lines into themselves.</source>
+        <translation>Çizgileri kendi içlerine taşıyın.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5860"/>
+        <source>%n lines moved.</source>
+        <translation>
+            <numerusform>%n satır geçildi.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5920"/>
+        <source>File &quot;%1&quot; exists (add ! to override)</source>
+        <translation>&quot;%1&quot; dosyası var (geçersiz kılmak için! ekleyin)</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5934"/>
+        <source>Cannot open file &quot;%1&quot; for writing</source>
+        <translation>&quot;%1&quot; dosyası yazmak için açılamıyor</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5940"/>
+        <source>&quot;%1&quot; %2 %3L, %4C written.</source>
+        <translation>&quot;%1&quot; %2 %3L, %4C yazıldı.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5949"/>
+        <source>Cannot open file &quot;%1&quot; for reading</source>
+        <translation>&quot;%1&quot; dosyası okumak için açılamıyor</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5978"/>
+        <source>&quot;%1&quot; %2L, %3C</source>
+        <translation>&quot;%1&quot; %2L, %3C</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6005"/>
+        <source>%n lines filtered.</source>
+        <translation>
+            <numerusform>%n satır filtrelendi.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6093"/>
+        <source>Cannot open file %1</source>
+        <translation>%1 dosyası açılamadı</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6259"/>
+        <source>Invalid regular expression: %1</source>
+        <translation>Geçersiz düzenli ifade: %1</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6295"/>
+        <source>Pattern not found: %1</source>
+        <translation>Kalıp bulunamadı: %1</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6299"/>
+        <source>Search hit BOTTOM, continuing at TOP.</source>
+        <translation>Arama SON&apos;a geldi, BAŞ&apos;tan devam edecek.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6300"/>
+        <source>Search hit TOP, continuing at BOTTOM.</source>
+        <translation>Arama, SONDAN&apos;da devam ederek BAŞA&apos;a ulaştı.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6305"/>
+        <source>Search hit BOTTOM without match for: %1</source>
+        <translation>Eşleşmeden SONA ulaşıldı:%1</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6306"/>
+        <source>Search hit TOP without match for: %1</source>
+        <translation>Eşleşmeden BAŞA ulaşıldı:%1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6413"/>
+        <source>%n lines indented.</source>
+        <translation>
+            <numerusform>%n satır girintili.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6470"/>
+        <source>%n lines %1ed %2 time.</source>
+        <translation>
+            <numerusform>%n satır %1er %2 kez.</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="7043"/>
+        <source>%n lines yanked.</source>
+        <translation>
+            <numerusform>%n çizgi çekildi.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="7748"/>
+        <source>Already at oldest change.</source>
+        <translation>Zaten en eski değişimde.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="7749"/>
+        <source>Already at newest change.</source>
+        <translation>Zaten son değişiklikte.</translation>
+    </message>
+</context>
+<context>
+    <name>FakeVim::Internal::FakeVimHandler::Private</name>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="2788"/>
+        <source>Recursive mapping</source>
+        <translation>Yinelemeli haritalama</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="4195"/>
+        <source>Type Alt-V, Alt-V to quit FakeVim mode.</source>
+        <translation>FakeVim modundan çıkmak için Alt-V, Alt-V yapın.</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="5941"/>
+        <source> [New] </source>
+        <translation> [Yeni] </translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/fakevim/fakevim/fakevimhandler.cpp" line="6166"/>
+        <source>Not an editor command: %1</source>
+        <translation>%1 düzenleyici komutu değil</translation>
+    </message>
+</context>
+<context>
+    <name>FakeVimEdit</name>
+    <message>
+        <location filename="src/plugins/fakevimedit/fakevimedit.cpp" line="68"/>
+        <source>Use FakeVim Editing</source>
+        <translation>FakeVim Düzenlemeyi Kullanın</translation>
+    </message>
+</context>
+<context>
+    <name>FakeVimEditOption</name>
+    <message>
+        <location filename="src/plugins/fakevimedit/fakevimeditoption.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/fakevimedit/fakevimeditoption.ui" line="20"/>
+        <source>FakeVim initialization command list (# start is comment):</source>
+        <translation>FakeVim başlatma komut listesi (# başlangıç yorumdur):</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/fakevimedit/fakevimeditoption.ui" line="28"/>
+        <source>Load default init command list</source>
+        <translation>Varsayılan başlangıç komut listesini yükle</translation>
     </message>
 </context>
 <context>
@@ -727,74 +1220,80 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/plugins/litetty/fifotty.cpp" line="86"/>
         <source>Cannot create temporary file: %1</source>
-        <translation>Geçici dosya yaratılamıyor: %1</translation>
+        <translation>Geçici dosya oluşturulamıyor: %1</translation>
     </message>
     <message>
         <location filename="src/plugins/litetty/fifotty.cpp" line="97"/>
         <source>Cannot create FiFo %1: %2</source>
-        <translation>FiFo %1 yaratılamıyor: %2</translation>
+        <translation>FiFo oluşturulamıyor %1:%2</translation>
     </message>
     <message>
         <location filename="src/plugins/litetty/fifotty.cpp" line="104"/>
         <source>Cannot open FiFo %1: %2</source>
-        <translation>FiFo %1 açılamıyor: %2</translation>
+        <translation>FiFo açılamıyor %1:%2</translation>
     </message>
 </context>
 <context>
     <name>FileBrowser</name>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="88"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="98"/>
         <source>Synchronize with editor</source>
-        <translation>Editörü senkronize et</translation>
+        <translation>Editörle senkronize et</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="93"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="103"/>
         <source>Show Hidden Files</source>
         <translation>Gizli Dosyaları Göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="144"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="159"/>
         <source>Set As Root Folder</source>
         <oldsource>Set Folder To Root</oldsource>
-        <translation>Kök Dizin Olarak İşaretle</translation>
+        <translation>Kök Klasör olarak ayarla</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="100"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="119"/>
         <source>Execute File</source>
         <translation>Dosyayı Çalıştır</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="91"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="101"/>
         <source>Reload Folder</source>
-        <translation>Dizini Yenile</translation>
+        <translation>Klasörü Tekrak Yükle</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="145"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="110"/>
+        <source>Show Details</source>
+        <translation>Ayrıntıları Göster</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="122"/>
+        <source>Debug File</source>
+        <translation>Hata Ayıklama Dosyası</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="160"/>
         <source>Open Folder in New Window</source>
-        <translation>Dizini Yeni Pencerede Aç</translation>
+        <translation>Klasörü Yeni Pencerede Aç</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="146"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="161"/>
         <source>Add to Folders</source>
-        <translation>Dizinlere Ekle</translation>
+        <translation>Klasörlere Ekle</translation>
     </message>
     <message>
-        <source>Config</source>
-        <translation type="obsolete">Ayarlar</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="119"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="141"/>
         <source>Open Parent</source>
         <oldsource>Open to Parent</oldsource>
-        <translation>Üst Dizini Aç</translation>
+        <translation>Üst Öğeyi Aç</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="154"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="169"/>
         <source>Filter</source>
         <translation>Filtrele</translation>
     </message>
     <message>
-        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="159"/>
+        <location filename="src/plugins/filebrowser/filebrowser.cpp" line="175"/>
         <source>File System</source>
         <translation>Dosya Sistemi</translation>
     </message>
@@ -809,7 +1308,7 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/plugins/filebrowser/filebrowseroption.ui" line="20"/>
         <source>Terminal</source>
-        <translation>Komut Satırı</translation>
+        <translation>Terminal</translation>
     </message>
     <message>
         <location filename="src/plugins/filebrowser/filebrowseroption.ui" line="26"/>
@@ -819,114 +1318,90 @@ LiteIDE sade, açık kaynaklı ve platform bağımsız bir geliştirme ortamıd�
     <message>
         <location filename="src/plugins/filebrowser/filebrowseroption.ui" line="36"/>
         <source>Arguments:</source>
-        <translation>Parametreler:</translation>
+        <translation>Argümanlar:</translation>
     </message>
 </context>
 <context>
     <name>FileManager</name>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="182"/>
-        <location filename="src/liteapp/filemanager.cpp" line="203"/>
-        <location filename="src/liteapp/filemanager.cpp" line="224"/>
+        <location filename="src/liteapp/filemanager.cpp" line="189"/>
+        <location filename="src/liteapp/filemanager.cpp" line="211"/>
+        <location filename="src/liteapp/filemanager.cpp" line="233"/>
         <source>All Files (*)</source>
         <translation>Tüm Dosyalar (*)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="395"/>
+        <location filename="src/liteapp/filemanager.cpp" line="397"/>
         <source>LiteIDE</source>
         <translation>LiteIDE</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="396"/>
+        <location filename="src/liteapp/filemanager.cpp" line="398"/>
         <source>Project &apos;%1&apos; has been created.
 Do you want to open it now?</source>
         <oldsource>Project &apos;%1&apos; is created.
 Do you want to load?</oldsource>
-        <translation>&apos;%1&apos; projesi yaratıldı.
-Yüklemek ister misin?</translation>
+        <translation>&apos;%1&apos; projesi oluşturuldu.
+Şimdi açmak ister misin?</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="301"/>
         <source>Open Project or File</source>
-        <translation>Dosya veya Proje Aç</translation>
+        <translation>Proje veya Dosya Aç</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="79"/>
+        <location filename="src/liteapp/filemanager.cpp" line="76"/>
         <source>Show Hidden Files</source>
         <translation>Gizli Dosyaları Göster</translation>
     </message>
     <message>
-        <source>Config</source>
-        <translation type="obsolete">Ayarlar</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/filemanager.cpp" line="95"/>
+        <location filename="src/liteapp/filemanager.cpp" line="127"/>
         <source>Folders</source>
         <oldsource>Folers</oldsource>
-        <translation>Dizinler</translation>
+        <translation>Klasörler</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="103"/>
-        <source>Clear History</source>
-        <translation>Geçmişi Sil</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/filemanager.cpp" line="179"/>
-        <location filename="src/liteapp/filemanager.cpp" line="200"/>
-        <location filename="src/liteapp/filemanager.cpp" line="221"/>
+        <location filename="src/liteapp/filemanager.cpp" line="186"/>
+        <location filename="src/liteapp/filemanager.cpp" line="208"/>
+        <location filename="src/liteapp/filemanager.cpp" line="230"/>
         <source>All Support Files (%1)</source>
-        <translation>Tüm Yardım Dosyaları (%1)</translation>
+        <translation>Tüm Desteklenen Dosyalar (%1)</translation>
     </message>
     <message>
         <location filename="src/liteapp/filemanager.cpp" line="314"/>
         <location filename="src/liteapp/filemanager.cpp" line="332"/>
         <source>Select a folder:</source>
         <oldsource>Open Folder</oldsource>
-        <translation>Bir dizin seç:</translation>
+        <translation>Klasör Seç:</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="529"/>
-        <source>Session</source>
-        <translation>Oturum</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/filemanager.cpp" line="530"/>
-        <source>Project</source>
-        <translation>Proje</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/filemanager.cpp" line="531"/>
-        <source>File</source>
-        <translation>Dosya</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/filemanager.cpp" line="532"/>
-        <source>Folder</source>
-        <translation>Dizin</translation>
-    </message>
-    <message>
-        <location filename="src/liteapp/filemanager.cpp" line="785"/>
+        <location filename="src/liteapp/filemanager.cpp" line="679"/>
         <source>%1
 This file has been deleted from the drive,
 but you have unsaved modifications in your LiteIDE editor.
 
 Do you want to close the editor?
 Answering &quot;Yes&quot; will discard your unsaved changes.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1
+Bu dosya sürücüden silindi,
+ancak LiteIDE düzenleyicinizde kaydedilmemiş değişiklikleriniz var.
+
+Editörü kapatmak istiyor musunuz?
+&quot;Evet&quot; cevabı, kaydedilmemiş değişikliklerinizin silinmesine neden olur.</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="792"/>
+        <location filename="src/liteapp/filemanager.cpp" line="686"/>
         <source>%1
 This file has been deleted from the drive.
 
 Do you want to close the editor?</source>
         <translation>%1
-Bu dosya sabit diskten silindi.
+Bu dosya sürücüden silinmiştir.
 
-Editörü kapatmak ister misiniz?</translation>
+Editörü kapatmak istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="822"/>
+        <location filename="src/liteapp/filemanager.cpp" line="719"/>
         <source>%1
 This file has been modified on the drive,
 but you have unsaved modifications in your LiteIDE editor.
@@ -934,128 +1409,149 @@ but you have unsaved modifications in your LiteIDE editor.
 Do you want to reload the file from disk?
 Answering &quot;Yes&quot; will discard your unsaved changes.</source>
         <translation>%1
-Bu dosya sabit diskte değişikliğe uğradı ancak,
-LiteIDE editöründe henüz kaydedilmemiş değişiklikleriniz var.
+Bu dosya sürücüde değiştirildi,
+ancak LiteIDE düzenleyicinizde kaydedilmemiş değişiklikleriniz var.
 
-Dosya içeriği diskten okunarak güncellensin mi?
-&quot;Evet&quot; demeniz halinde kaydedilmemiş değişiklikleriniz gözardı edilecek.
-        </translation>
+Dosyayı diskten yeniden yüklemek istiyor musunuz?
+&quot;Evet&quot; cevabı, kaydedilmemiş değişikliklerinizin silinmesine neden olur.</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="829"/>
+        <location filename="src/liteapp/filemanager.cpp" line="726"/>
         <source>%1
 This file has been modified on the drive.
 
 Do you want to reload the file from disk?</source>
         <translation>%1
-Bu dosya sabit diskte değişikliğe uğradı.
+Sürücüdeki dosya değiştirilmiş.
 
-Dosya içeriği diskten okunarak güncellensin mi?</translation>
+Diskteki dosyayı yeniden yüklemek istermisiniz?</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="351"/>
+        <location filename="src/liteapp/filemanager.cpp" line="350"/>
         <source>Open Files</source>
         <translation>Dosyaları Aç</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="86"/>
-        <source>Synchronize with editor</source>
-        <translation>Editör ile senkronize et</translation>
+        <location filename="src/liteapp/filemanager.cpp" line="79"/>
+        <source>Show Details</source>
+        <translation>Ayrıntıları Göster</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="90"/>
+        <location filename="src/liteapp/filemanager.cpp" line="82"/>
+        <source>Synchronize with editor</source>
+        <translation>Editörle Senkronizasyon</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/filemanager.cpp" line="85"/>
+        <source>Split Mode</source>
+        <translation>Bölme Modu</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/filemanager.cpp" line="113"/>
         <source>Filter</source>
         <translation>Filtrele</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="364"/>
+        <location filename="src/liteapp/filemanager.cpp" line="363"/>
         <source>Open Project</source>
         <translation>Proje Aç</translation>
     </message>
     <message>
-        <location filename="src/liteapp/filemanager.cpp" line="789"/>
-        <location filename="src/liteapp/filemanager.cpp" line="794"/>
-        <location filename="src/liteapp/filemanager.cpp" line="826"/>
-        <location filename="src/liteapp/filemanager.cpp" line="831"/>
+        <location filename="src/liteapp/filemanager.cpp" line="683"/>
+        <location filename="src/liteapp/filemanager.cpp" line="688"/>
+        <location filename="src/liteapp/filemanager.cpp" line="723"/>
+        <location filename="src/liteapp/filemanager.cpp" line="728"/>
         <source>LiteIDE X</source>
         <translation>LiteIDE X</translation>
     </message>
 </context>
 <context>
+    <name>FileRecent</name>
+    <message>
+        <location filename="src/liteapp/recentmanager.h" line="135"/>
+        <source>Files</source>
+        <translation>Dosyalar</translation>
+    </message>
+</context>
+<context>
     <name>FileSearch</name>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="203"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="217"/>
         <source>Match whole word</source>
         <oldsource>Match word</oldsource>
-        <translation>Tüm kelimeleri eşleştir</translation>
+        <translation>Tüm kelimeyi eşleştir</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="204"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="218"/>
         <source>Match case</source>
-        <translation>Büyük/küçük harf duyarlı</translation>
+        <translation>Büyük / küçük harf eşleştir</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="205"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="219"/>
         <source>Regular expression</source>
         <translation>Düzenli ifade</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="206"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="220"/>
         <source>Scan subdirectories</source>
         <oldsource>Look in subdirs</oldsource>
         <translation>Alt dizinleri tara</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="226"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="241"/>
         <source>Search for:</source>
-        <translation>Şunu ara:</translation>
+        <translation>Aranacak:</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="228"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="243"/>
         <source>Options:</source>
         <translation>Ayarlar:</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="234"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="250"/>
         <source>Browse...</source>
         <oldsource>Browser</oldsource>
-        <translation>Gözat...</translation>
+        <translation>Araştır...</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="235"/>
-        <source>Use Current</source>
-        <oldsource>Current</oldsource>
-        <translation>Varsayılanı Kullan</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="252"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="273"/>
         <source>Filter:</source>
-        <translation>Filtrele:</translation>
+        <translation>Filtre:</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="339"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="365"/>
         <source>Files on File System</source>
-        <translation>Sabit Diskteki Dosyalar</translation>
+        <translation>Sistemdeki dosyalar</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="215"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="230"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="216"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="231"/>
         <source>Cancel</source>
-        <translation>Vazgeç</translation>
+        <translation>İptal</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="257"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="251"/>
+        <source>Current Folder</source>
+        <translation>Geçerli Klasör</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="254"/>
+        <source>Auto Switch</source>
+        <translation>Otomatik Geçiş</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="278"/>
         <source>Clear</source>
         <translation>Temizle</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearch.cpp" line="444"/>
+        <location filename="src/plugins/litefind/filesearch.cpp" line="480"/>
         <source>Open Directory</source>
-        <translation>Dizini Aç</translation>
+        <translation>Klasör Aç</translation>
     </message>
 </context>
 <context>
@@ -1063,13 +1559,13 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="50"/>
         <source>Search Item:</source>
-        <translation>Öğe Ara:</translation>
+        <translation>Arama Öğesi:</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="69"/>
         <source>Only golang file changes can be revert!</source>
         <oldsource>This file change cannot be undone!</oldsource>
-        <translation>Sadece golang dosya değişiklikleri geri alınabilir!</translation>
+        <translation>Yalnızca golang dosyası değişiklikleri geri alınabilir!</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/filesearchmanager.cpp" line="83"/>
@@ -1077,19 +1573,44 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <translation>Yeni Arama</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="86"/>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="85"/>
+        <source>File Search</source>
+        <translation>Dosya Ara</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="89"/>
         <source>Search Result</source>
-        <translation>Arama Sonuçları</translation>
+        <translation>Arama Sonucu</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="233"/>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="248"/>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="253"/>
+        <source>LiteIDE X</source>
+        <translation>LiteIDE X</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="248"/>
+        <source>Warning! Replace text is empty.
+Want to remove all the search items?</source>
+        <translation>Uyarı! Değiştirme metni boş
+Tüm arama öğelerini silmek mı istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="253"/>
+        <source>Warning! Replace text is whitespace.
+Want to replace to all the search items to whitespace?</source>
+        <translation>Uyarı! Değiştirme metni boşluk karakteri
+Tüm arama öğelerini boşluk karkteri yapmak mı istiyorsunuz?</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="280"/>
         <source>The following files have no write permissions. Do you want to change the permissions?</source>
-        <translation>Aşağıdaki dosyalara yazma izni yok? Yazma izni için yetki değişikliği yapılsın mı?</translation>
+        <translation>Aşağıdaki dosyaların yazma izni yoktur. İzinleri değiştirmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="236"/>
+        <location filename="src/plugins/litefind/filesearchmanager.cpp" line="283"/>
         <source>File is readonly</source>
-        <translation>Bu dosya salt-okunur</translation>
+        <translation>Dosya saltokunur</translation>
     </message>
 </context>
 <context>
@@ -1117,7 +1638,7 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="326"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="331"/>
         <source>Rename File</source>
-        <translation>Dosya Adını Değiştir</translation>
+        <translation>Dosya Yeniden Adlandır</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="98"/>
@@ -1125,25 +1646,25 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="350"/>
         <source>Delete File</source>
         <oldsource>Remove File</oldsource>
-        <translation>Dosyayı Sil</translation>
+        <translation>Dosya Sil</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="100"/>
         <source>New Folder...</source>
         <oldsource>New Folder</oldsource>
-        <translation>Yeni Dizin...</translation>
+        <translation>Yeni Klasör...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="346"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bo dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="386"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="395"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="400"/>
         <source>Rename Folder</source>
-        <translation>Dizini Yeniden Adlandır</translation>
+        <translation>Klasör Yeniden Adlandır</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="102"/>
@@ -1151,52 +1672,52 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="421"/>
         <source>Delete Folder</source>
         <oldsource>Remove Folder</oldsource>
-        <translation>Dizini Sil</translation>
+        <translation>Klasör Sil</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="97"/>
         <source>Rename File...</source>
-        <translation>Dosyayı Yeniden Adlandır...</translation>
+        <translation>Dosya Adı Değiştir...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="101"/>
         <source>Rename Folder...</source>
-        <translation>Dizini Yeniden Adlandır...</translation>
+        <translation>Klasör Adı Değiştir...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="104"/>
         <source>Open Terminal Here</source>
-        <translation>Burada Komut Satırını Aç</translation>
+        <translation>Terminali Burada Aç</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="105"/>
         <source>Open Explorer Here</source>
-        <translation>Burayı Dizinde Göster</translation>
+        <translation>Exploreri Burada Aç</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="107"/>
         <source>View Godoc Here</source>
-        <translation>Burada Godoc Göster</translation>
+        <translation>Godoc Görüntüle</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="454"/>
         <source>Add Folder</source>
-        <translation>Dizin Ekle</translation>
+        <translation>Klasör Ekle</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="110"/>
         <source>Close Folder</source>
-        <translation>Dizini Kapat</translation>
+        <translation>Klasörü Kapat</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="109"/>
         <source>Add Folder...</source>
-        <translation>Dizin Ekle...</translation>
+        <translation>Klasör Ekle...</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="112"/>
         <source>Close All Folders</source>
-        <translation>Tüm Dizinleri Kapat</translation>
+        <translation>Bütün Klasörleri Kapat</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="279"/>
@@ -1208,12 +1729,12 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="280"/>
         <source>A file with that name already exists!</source>
         <oldsource>The file already exists!</oldsource>
-        <translation>Bu isimde bir dosya zaten mevcut!</translation>
+        <translation>Bu isimde bir dosya zaten var!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="290"/>
         <source>Failed to create the file!</source>
-        <translation>Dosya yaratılamıyor!</translation>
+        <translation>Dosya oluşturulamadı!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="320"/>
@@ -1224,52 +1745,52 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="327"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="332"/>
         <source>Failed to rename the file!</source>
-        <translation>Dosya İsmi Değiştirilemiyor!</translation>
+        <translation>Dosya yeniden adlandırılamadı!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="415"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
+        <translation>Bu klasörü ve tüm içeriğini kalıcı olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="351"/>
         <source>Failed to delete the file!</source>
         <oldsource>Failed to remove the file!</oldsource>
-        <translation>Dosya silinemiyor!</translation>
+        <translation>Dosya Silinemedi!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="369"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="372"/>
         <source>Create Folder</source>
-        <translation>Dizin Oluştur</translation>
+        <translation>Klasör Oluştır</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="370"/>
         <source>A folder with that name already exists!</source>
         <oldsource>The folder name is exists!</oldsource>
-        <translation>Bu isimde bir dizin zaten mevcut!</translation>
+        <translation>Bu isimde bir klasör zaten var!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="373"/>
         <source>Failed to create the folder!</source>
-        <translation>Dizin oluşturulamıyor!</translation>
+        <translation>Klasör oluşturulamadı!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="386"/>
         <source>Folder Name</source>
-        <translation>Dizin Adı</translation>
+        <translation>Klasör Adı</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="396"/>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="401"/>
         <source>Failed to rename the folder!</source>
-        <translation>Dizin adı değiştirilemiyor!</translation>
+        <translation>Klasör Adı Değiştirilemedi!</translation>
     </message>
     <message>
         <location filename="src/utils/filesystem/filesystemwidget.cpp" line="422"/>
         <source>Failed to delete the folder!</source>
         <oldsource>Failed to remove the folder!</oldsource>
-        <translation>Dizin silinemiyor!</translation>
+        <translation>Klasör silinemedi!</translation>
     </message>
 </context>
 <context>
@@ -1282,12 +1803,12 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="163"/>
         <source>Cancel</source>
-        <translation>Vazgeç</translation>
+        <translation>İptal</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="167"/>
         <source>Repeat the search with same parameters</source>
-        <translation>Aramayı aynı parametrelerle tekrar yap</translation>
+        <translation>Aramayı aynı parametrelerle yap</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="168"/>
@@ -1297,86 +1818,102 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="174"/>
         <source>Set show replace mode ui</source>
-        <translation>Değişiklik yapma modunu göster</translation>
+        <translation>UI modunu ayarla</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="175"/>
         <source>Show Replace</source>
-        <translation>Değiştir</translation>
+        <translation>Değiştir&apos;i Göster</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="180"/>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="437"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="441"/>
         <source>Replace with:</source>
-        <translation>Şununla değiştir:</translation>
+        <translation>Değiştir:</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="186"/>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="438"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="442"/>
         <source>Replace all occurrences</source>
         <translation>Tümünü değiştir</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="187"/>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="439"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="443"/>
         <source>Replace</source>
         <translation>Değiştir</translation>
     </message>
     <message>
         <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="191"/>
         <source>Preserve case</source>
-        <translation>BÜYÜK/Küçük harfleri koru</translation>
+        <translation>Cümleyi koru</translation>
     </message>
     <message>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="304"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="204"/>
+        <source>Expand all items</source>
+        <translation>Tüm öğeleri genişlet</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="209"/>
+        <source>Collapse all items</source>
+        <translation>Tüm öğeleri daralt</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="318"/>
         <source>Revert with:</source>
-        <translation>Şununla geri al:</translation>
+        <translation>Şununla geri dön:</translation>
     </message>
     <message>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="305"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="319"/>
         <source>Revert</source>
-        <translation>Geri Al</translation>
+        <translation>Geri al</translation>
     </message>
     <message>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="306"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="320"/>
         <source>Revert all occurrences</source>
-        <translation>Tümünü Geri Al</translation>
+        <translation>Tüm değişiklikleri geri al</translation>
     </message>
     <message numerus="yes">
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="575"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="592"/>
         <source>%n matches replaced.</source>
-        <translation>%n eşleşme değiştirildi</translation>
+        <translation>
+            <numerusform>%n eşleşme değiştirildi.</numerusform>
+        </translation>
     </message>
     <message numerus="yes">
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="577"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="594"/>
         <source>searching... %n matches found.</source>
-        <translation>aranıyor... %n eşleşme bulundu.</translation>
+        <translation>
+            <numerusform>aranıyor... %n eşleşme bulundu.</numerusform>
+        </translation>
     </message>
     <message>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="583"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="600"/>
         <source>searching ...</source>
-        <translation>aranıyor ...</translation>
+        <translation>aranıyor...</translation>
     </message>
     <message>
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="589"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="606"/>
         <source>No matches found.</source>
-        <translation>Hiç sonuç bulunamadı.</translation>
+        <translation>Eşleşme bulunamadı.</translation>
     </message>
     <message numerus="yes">
-        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="591"/>
+        <location filename="src/3rdparty/qtc_searchresult/searchresultwidget.cpp" line="608"/>
         <source>%n matches found.</source>
-        <translation>%n sonuç found</translation>
+        <translation>
+            <numerusform>%n eşleşme bulundu.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
     <name>FindApiEdit</name>
     <message>
-        <location filename="src/plugins/golangdoc/findapiwidget.h" line="69"/>
+        <location filename="src/plugins/golangdoc/findapiwidget.h" line="73"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangdoc/findapiwidget.h" line="70"/>
+        <location filename="src/plugins/golangdoc/findapiwidget.h" line="74"/>
         <source>Stop Search</source>
         <translation>Aramayı Durdur</translation>
     </message>
@@ -1384,91 +1921,86 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
 <context>
     <name>FindApiWidget</name>
     <message>
-        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="269"/>
+        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="284"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="282"/>
-        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="315"/>
+        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="305"/>
+        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="337"/>
         <source>Find</source>
         <translation>Bul</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangdoc/findapiwidget.cpp" line="313"/>
-        <source>Rebuild database</source>
-        <translation>Veritabanını yeniden indeksle</translation>
     </message>
 </context>
 <context>
     <name>FindDocWidget</name>
     <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="94"/>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="96"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="102"/>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="104"/>
         <source>Find</source>
         <translation>Bul</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="121"/>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="123"/>
         <source>Find All</source>
-        <translation>Tümünü Bul</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="122"/>
-        <source>Find const</source>
-        <translation>Sabit bul (const)</translation>
+        <translation>Hepsini Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="124"/>
-        <source>Find func</source>
-        <translation>Fonksiyon bul (func)</translation>
+        <source>Find const</source>
+        <translation>Const Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="126"/>
-        <source>Find interface</source>
-        <translation>Arayüz bul (interface)</translation>
+        <source>Find func</source>
+        <translation>Fonksiyon Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="128"/>
-        <source>Find pkg</source>
-        <translation>Paket bul (pkg)</translation>
+        <source>Find interface</source>
+        <translation>Arayüz Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="130"/>
-        <source>Find struct</source>
-        <translation>Yapı bul (struct)</translation>
+        <source>Find pkg</source>
+        <translation>pkg Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="132"/>
-        <source>Find type</source>
-        <translation>Tip bul (type)</translation>
+        <source>Find struct</source>
+        <translation>struct Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="134"/>
-        <source>Find var</source>
-        <translation>Değişken bul (var)</translation>
+        <source>Find type</source>
+        <translation>Tür Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="136"/>
-        <source>Use Regexp</source>
-        <translation>Düzenli İfade Kullan</translation>
+        <source>Find var</source>
+        <translation>var Bul</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="138"/>
-        <source>Match Case</source>
-        <translation>BÜYÜK/Küçük Harfe Duyarlı</translation>
+        <source>Use Regexp</source>
+        <translation>Düzenli ifade kullan</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="140"/>
+        <source>Match Case</source>
+        <translation>Büyük / küçük harf eşleştir</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="142"/>
         <source>Match Word</source>
         <translation>Kelime Eşleştir</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="167"/>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="169"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
@@ -1478,17 +2010,17 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="63"/>
         <source>Match case</source>
-        <translation>BÜYÜK/Küçük Harfe Duyarlı</translation>
+        <translation>Büyük / küçük harf eşleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="64"/>
         <source>Regular expression</source>
-        <translation>Düzenli ifade</translation>
+        <translation>Düzenli İfade</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="65"/>
         <source>Wrap around</source>
-        <translation>Etrafında Ara</translation>
+        <translation>Sözcük Kaydırma</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="56"/>
@@ -1504,7 +2036,7 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="58"/>
         <source>Replace With:</source>
-        <translation>Şununla değiştir:</translation>
+        <translation>Değiştir:</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="59"/>
@@ -1519,12 +2051,12 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="62"/>
         <source>Match whole word only</source>
-        <translation>Tüm cümleyi eşleştir</translation>
+        <translation>Tüm Kelimeyi Eşleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/findeditor.cpp" line="72"/>
-        <location filename="src/plugins/litefind/findeditor.cpp" line="238"/>
-        <location filename="src/plugins/litefind/findeditor.cpp" line="441"/>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="249"/>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="470"/>
         <source>Ready</source>
         <translation>Hazır</translation>
     </message>
@@ -1534,19 +2066,24 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/findeditor.cpp" line="99"/>
-        <source>Find What:</source>
-        <translation>Şunu Bul:</translation>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="84"/>
+        <source>Show Replace</source>
+        <translation>Değiştirmeyi Göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/findeditor.cpp" line="110"/>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="103"/>
+        <source>Find What:</source>
+        <translation>Aranan:</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="115"/>
         <source>Options:</source>
         <oldsource>Find Option:</oldsource>
         <translation>Ayarlar:</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/findeditor.cpp" line="209"/>
-        <location filename="src/plugins/litefind/findeditor.cpp" line="364"/>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="220"/>
+        <location filename="src/plugins/litefind/findeditor.cpp" line="392"/>
         <source>Not found</source>
         <translation>Bulunamadı</translation>
     </message>
@@ -1554,71 +2091,79 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
 <context>
     <name>FolderListView</name>
     <message>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="268"/>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="278"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="249"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="259"/>
         <source>Delete File</source>
-        <translation>Dosyayı Sil</translation>
+        <translation>Dosya Sil</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="269"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="250"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bu dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="279"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="260"/>
         <source>Failed to delete the file!</source>
-        <translation>Dosya silinemiyor!</translation>
+        <translation>Dosya silinemedi!</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="291"/>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="301"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="272"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="282"/>
         <source>Delete Folder</source>
-        <translation>Dizini Sil</translation>
+        <translation>Klasör Sil</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="292"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="273"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
+        <translation>Bu klasörü ve tüm içeriğini kalıcı olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderlistview.cpp" line="302"/>
+        <location filename="src/utils/folderview/folderlistview.cpp" line="283"/>
         <source>Failed to delete the folder!</source>
-        <translation>Dizin silinemiyor!</translation>
+        <translation>Klasör Silinemedi!</translation>
+    </message>
+</context>
+<context>
+    <name>FolderRecent</name>
+    <message>
+        <location filename="src/liteapp/recentmanager.h" line="166"/>
+        <source>Folders</source>
+        <translation>Klasörler</translation>
     </message>
 </context>
 <context>
     <name>FolderView</name>
     <message>
-        <location filename="src/utils/folderview/folderview.cpp" line="148"/>
-        <location filename="src/utils/folderview/folderview.cpp" line="158"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="173"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="183"/>
         <source>Delete File</source>
-        <translation>Dosyayı Sil</translation>
+        <translation>Dosya Sil</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderview.cpp" line="149"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="174"/>
         <source>Are you sure that you want to permanently delete this file?</source>
-        <translation>Bu dosyayı kalıcı olarak silmek istediğinize emin misiniz?</translation>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderview.cpp" line="159"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="184"/>
         <source>Failed to delete the file!</source>
-        <translation>Dosya silinemiyor!</translation>
+        <translation>Dosya Silinemedi!</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderview.cpp" line="171"/>
-        <location filename="src/utils/folderview/folderview.cpp" line="181"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="230"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="240"/>
         <source>Delete Folder</source>
-        <translation>Dizini Sil</translation>
+        <translation>Klasör Sil</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderview.cpp" line="172"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="231"/>
         <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
-        <translation>Bu dizini içindeki tüm alt dizin ve dosyalarla birlikte silmek istediğinize emin misiniz?</translation>
+        <translation>Bu klasörü ve tüm içeriğini kalıcı olarak silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location filename="src/utils/folderview/folderview.cpp" line="182"/>
+        <location filename="src/utils/folderview/folderview.cpp" line="241"/>
         <source>Failed to delete the folder!</source>
-        <translation>Dizin silinemiyor!</translation>
+        <translation>Klasör Silinemedi!</translation>
     </message>
 </context>
 <context>
@@ -1631,25 +2176,206 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/gdbdebugger/gdbdebuggeroption.ui" line="20"/>
         <source>Enable --tty for program being debugged.</source>
-        <translation>Hata ayıklarken --tty açık kalsın.</translation>
+        <translation>Hata ayıklanan program için --tty&apos;yi etkinleştirin.</translation>
+    </message>
+</context>
+<context>
+    <name>GoAddTagsDialog</name>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="14"/>
+        <source>Add Tags To Struct Field</source>
+        <translation>Struct Alanına Etiket Ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="23"/>
+        <source>Add JSON Tag</source>
+        <translation>JSON etiketi ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="54"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="105"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="169"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="197"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="281"/>
+        <source>Options</source>
+        <translation>Ayarlar</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="61"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="112"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="176"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="204"/>
+        <source>Multiple options separated by commas</source>
+        <oldsource>Multiple options are separated by commas</oldsource>
+        <translation>Virgülle ayrılmış birden çok seçenek</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="74"/>
+        <source>Add XML Tag</source>
+        <translation>XML etiketi ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="125"/>
+        <source>Add Custom Tags</source>
+        <translation>Özel etiket ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="155"/>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="187"/>
+        <source>Tag Name</source>
+        <translation>Etilet İsmi</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="162"/>
+        <source>Setup custom tag name</source>
+        <translation>Özel etiket adı ayarla</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="299"/>
+        <source>Sort sorts the tags in increasing order according to the key name</source>
+        <translation>Etiket anahtarları adına göre artan şekilde sıralar</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="306"/>
+        <source>Override current tags when adding tags</source>
+        <translation>Etiket eklerken mevcut etiketleri geçersiz kıl</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goaddtagsdialog.ui" line="316"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
+    </message>
+</context>
+<context>
+    <name>GoRemoveTagsDialog</name>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="14"/>
+        <source>Remove Tags From Struct Field</source>
+        <translation>Struct Alanından Etiketleri Kaldır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="23"/>
+        <source>Remove Tags And Options</source>
+        <translation>Etiketleri ve Seçenekleri Kaldır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="29"/>
+        <source>Clear All Tags</source>
+        <translation>Tüm Etiketleri Temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="39"/>
+        <source>Clear All Tags Options</source>
+        <oldsource>Clear All Tag Options</oldsource>
+        <translation>Tüm Etiket Seçeneklerini Temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="46"/>
+        <source>Remove JSON Tag</source>
+        <translation>JSON etiketlerini temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="53"/>
+        <source>Remove XML Tag</source>
+        <translation>XML etiketlerini temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="60"/>
+        <source>Remove Custom Tag</source>
+        <translation>Özel etiketleri teminzle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="70"/>
+        <source>Multiple tags separated by commas</source>
+        <oldsource>Multiple tags  are separated by commas</oldsource>
+        <translation>Birden çok etiket, virgülle ayır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="77"/>
+        <source>Remove JSON Options</source>
+        <translation>JSON ayarlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="84"/>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="98"/>
+        <source>Multiple options separated by commas</source>
+        <oldsource>Multiple options are separated by commas</oldsource>
+        <translation>Çoklu seçenekler virgülle ayrılır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="91"/>
+        <source>Remove XML Options</source>
+        <translation>XML ayarlarını kaldır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="111"/>
+        <source>Remove Custom Tag Options</source>
+        <translation>Özel etiket ayarlarını temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="118"/>
+        <source>Setup remove custom tag and option, example tag=opt1,tag=opt2</source>
+        <oldsource>Setup remove custom tag option, example tag=opt1,tag=opt2</oldsource>
+        <translation>Özel etiketi ve seçeneği kaldır, örnek etiket = opt1, etiket = opt2</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="121"/>
+        <source>tag=option</source>
+        <translation>etiket=ayar</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/goremovetagsdialog.ui" line="131"/>
+        <source>Info</source>
+        <translation>Bilgi</translation>
     </message>
 </context>
 <context>
     <name>GolangAst</name>
     <message>
-        <location filename="src/plugins/golangast/golangast.cpp" line="58"/>
+        <location filename="src/plugins/golangast/golangast.cpp" line="60"/>
         <source>No outline available</source>
-        <translation>Hiç genel görünüm yok</translation>
+        <translation>Taslak mevcut değil</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangast/golangast.cpp" line="72"/>
-        <source>Class View</source>
-        <translation>Sınıf Görünümü</translation>
+        <location filename="src/plugins/golangast/golangast.cpp" line="74"/>
+        <location filename="src/plugins/golangast/golangast.cpp" line="77"/>
+        <source>Synchronize with editor</source>
+        <translation>Düzenletici ile senkronizasyon</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangast/golangast.cpp" line="73"/>
-        <source>Outline</source>
-        <translation>Genel görünüm</translation>
+        <location filename="src/plugins/golangast/golangast.cpp" line="80"/>
+        <source>Go Class View</source>
+        <oldsource>Class View</oldsource>
+        <translation>Go Sınıf Görünümü</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangast/golangast.cpp" line="81"/>
+        <source>Go Outline</source>
+        <oldsource>Outline</oldsource>
+        <translation>Go Taslağı</translation>
+    </message>
+</context>
+<context>
+    <name>GolangAstOption</name>
+    <message>
+        <location filename="src/plugins/golangast/golangastoption.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangast/golangastoption.ui" line="20"/>
+        <source>QuickOpenSymbol</source>
+        <translation>Hızlı Açma Sembolü</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangast/golangastoption.ui" line="26"/>
+        <source>Show import path</source>
+        <translation>İçe Aktarma Yolunu Göster</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangast/golangastoption.ui" line="33"/>
+        <source>Match case sensitive</source>
+        <translation>Büyük / küçük harfe duyarlı</translation>
     </message>
 </context>
 <context>
@@ -1661,20 +2387,35 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="20"/>
-        <source>Gocode</source>
-        <oldsource>Go API</oldsource>
-        <translation>Go kodu</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
-        <source>Auto update depends package when it&apos;s source changed.</source>
-        <oldsource>Auto update depends package when its source is changed.</oldsource>
-        <translation>Kullanılan paketlerin kaynak kodu değiştiğinde otomatik güncelle</translation>
+        <source>PKG automitic import prompt</source>
+        <translation>PKG otomatik içe aktarma istemi</translation>
     </message>
     <message>
         <location filename="src/plugins/golangcode/golangcodeoption.ui" line="26"/>
+        <source>PKG automatic import hints for all packages (GOPATH)</source>
+        <translation>Tüm paketler için PKG otomatik içe aktarma ipuçları (GOPATH)</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangcode/golangcodeoption.ui" line="33"/>
+        <source>PKG automatic import hints for standard package</source>
+        <translation>Standart paket için PKG otomatik içe aktarma ipuçları</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangcode/golangcodeoption.ui" line="43"/>
+        <source>Gocode</source>
+        <oldsource>Go API</oldsource>
+        <translation>Gocode</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangcode/golangcodeoption.ui" line="56"/>
+        <source>Auto update depends package when it&apos;s source changed.</source>
+        <oldsource>Auto update depends package when its source is changed.</oldsource>
+        <translation>Kaynak değiştiğinde pakete bağımlılıklarını otomatik güncelle.</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangcode/golangcodeoption.ui" line="49"/>
         <source>Close gocode when exiting</source>
-        <translation>Çıkarken go kodunu kapat</translation>
+        <translation>Çıkışta gocode kapat</translation>
     </message>
 </context>
 <context>
@@ -1682,22 +2423,24 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/golangdoc.cpp" line="100"/>
         <source>Godoc Search</source>
-        <translation type="unfinished">Godoc Ara</translation>
+        <translation>Godoc Arama</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/golangdoc.cpp" line="92"/>
-        <source>Golang Doc Search</source>
-        <translation>Golang Doc Ara</translation>
+        <source>Go Doc Search</source>
+        <oldsource>Golang Doc Search</oldsource>
+        <translation>Golang Doc Arama</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/golangdoc.cpp" line="96"/>
-        <source>Golang Api Index</source>
-        <translation>Golang Api Indeksi</translation>
+        <source>Go Api Index</source>
+        <oldsource>Golang Api Index</oldsource>
+        <translation>API indeksine git</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/golangdoc.cpp" line="111"/>
         <source>Find Package:</source>
-        <translation>Paket Bul:</translation>
+        <translation>Aranan Paket:</translation>
     </message>
 </context>
 <context>
@@ -1710,120 +2453,160 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangdoc/golangdocoption.ui" line="20"/>
         <source>Go API</source>
-        <translation>Go API</translation>
+        <translation>API&apos;ye Git</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/golangdocoption.ui" line="26"/>
         <source>Use default context (fast)</source>
-        <translation>Varsayılan context'i kullan (hızlı)</translation>
+        <translation>Standart kaynakları kullan (hızlı)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangdoc/golangdocoption.ui" line="33"/>
         <source>Only load standard API documentation</source>
         <oldsource>Only load standard api</oldsource>
-        <translation>Sadece standart API dökümanlarını yükle</translation>
+        <translation>Yalnızca standart API belgelerini yükleyin</translation>
     </message>
 </context>
 <context>
     <name>GolangEdit</name>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="73"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="90"/>
         <source>View import package use godoc</source>
-        <translation>Paket çağırma kullanımını göster</translation>
+        <translation>İçe aktarma paketini görüntüleyin, godoc kullanın</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="76"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="93"/>
         <source>View Expression Information</source>
-        <translation>Sözdizimi Bilgisini Göster</translation>
+        <translation>İfade Bilgilerini Görüntüle</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="79"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="96"/>
         <source>Jump to Declaration</source>
-        <translation>Tanımlanan yere git</translation>
+        <translation>Dekorasyona Git</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="82"/>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="88"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="99"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="105"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="108"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="111"/>
         <source>Find Usages</source>
-        <translation>Kullanılan Yerleri Bul</translation>
+        <translation>Kullanım Ara</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="85"/>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="91"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="102"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="114"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="117"/>
         <source>Rename Symbol Under Cursor</source>
-        <translation>İşaretçi altındaki sembolü yeniden adlandır</translation>
+        <translation>İmleç Altındaki Sembolü Yeniden Adlandır</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="136"/>
-        <source>Oracle</source>
-        <translation>Oracle</translation>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="111"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="114"/>
+        <source>%1 (Module/GOPATH) with GOROOT</source>
+        <translation>%1 (Module/GOPATH) GOROOT ile</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="138"/>
-        <source>Oracle What</source>
-        <oldsource>What</oldsource>
-        <translation>Oracle Nedir</translation>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="170"/>
+        <source>Stop</source>
+        <translation>Dur</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="142"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="175"/>
+        <source>Go Source Query</source>
+        <translation>Go Kaynak Sorgusu</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="180"/>
+        <source>SourceQuery What</source>
+        <translation>Kaynak Sorgusu</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="184"/>
         <source>Callees</source>
-        <translation>Çağrılanlar</translation>
+        <translation>Arananlar</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="146"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="188"/>
         <source>Callers</source>
-        <translation>Çağıranlar</translation>
+        <translation>Arayıcılar</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="150"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="192"/>
         <source>Callstack</source>
         <translation>Çağrı yığını</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="154"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="196"/>
         <source>Definition</source>
         <translation>Tanım</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="158"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="200"/>
         <source>Describe</source>
-        <translation>Açıklama</translation>
+        <translation>Tanımlamak</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="162"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="204"/>
         <source>Freevars</source>
-        <translation type="unfinished"></translation>
+        <translation>Taımsız Değişkenler</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="166"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="208"/>
         <source>Implements</source>
-        <translation>Implemente eder</translation>
+        <translation>Yerine getirme</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="170"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="212"/>
+        <source>Implements(GOPATH)</source>
+        <translation>Sağlanan (GOPATH)</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="216"/>
         <source>Peers</source>
-        <translation>Bağlar</translation>
+        <translation>Peers</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="174"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="220"/>
         <source>Referrers</source>
-        <translation>Referanslar</translation>
+        <translation>Yönlendirenler</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="178"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="224"/>
         <source>Pointsto</source>
-        <translation>İşaret edenler</translation>
+        <translation>Puanlar</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="182"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="228"/>
         <source>Whicherrs</source>
-        <translation>Soranlar</translation>
+        <translation>Hangisi</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="252"/>
-        <location filename="src/plugins/golangedit/golangedit.cpp" line="281"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="232"/>
+        <source>Add Tags To Struct Field</source>
+        <translation>Struct Alanına Etiket Ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="236"/>
+        <source>Remove Tags From Struct Field</source>
+        <translation>Struct Alanından Etiketleri Kaldır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="354"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="391"/>
         <source>Refactor</source>
-        <translation>Refaktör</translation>
+        <translation>Yeniden düzenleme</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="361"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="399"/>
+        <source>SourceQuery</source>
+        <translation>Kaynak Sorgusu</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="812"/>
+        <location filename="src/plugins/golangedit/golangedit.cpp" line="993"/>
+        <source>Below files in package %1</source>
+        <translation>%1 paketindeki dosyalar</translation>
     </message>
 </context>
 <context>
@@ -1840,21 +2623,26 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangeditoption.ui" line="26"/>
-        <source>Enable view expression infomation on mouse</source>
-        <translation>Fare üzerine geldiğinde sözdizimi bilgisi göster</translation>
+        <source>Go root source file editor setup read only</source>
+        <translation>Go kaynak dosya düzenleyici kurulumunu salt okunur yap</translation>
     </message>
     <message>
         <location filename="src/plugins/golangedit/golangeditoption.ui" line="33"/>
+        <source>Enable view expression infomation on mouse</source>
+        <translation>Fareyle görünüm ifadesi bilgilerini etkinleştir</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangedit/golangeditoption.ui" line="40"/>
         <source>Enable mouse navigation</source>
-        <translation>Fare ile navigasyonu etkinleştir</translation>
+        <translation>Fareyle gezinmeyi etkinleştir</translation>
     </message>
 </context>
 <context>
     <name>GolangFileSearch</name>
     <message>
-        <location filename="src/plugins/golangedit/golangfilesearch.cpp" line="54"/>
+        <location filename="src/plugins/golangedit/golangfilesearch.cpp" line="59"/>
         <source>Golang Find Usages</source>
-        <translation>Golang Kullanılan Yerleri Bul</translation>
+        <translation>Golang Kullanımları Bul</translation>
     </message>
 </context>
 <context>
@@ -1868,54 +2656,39 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="20"/>
         <source>Format Options</source>
         <oldsource>Golang Format</oldsource>
-        <translation>Format Ayarları</translation>
+        <translation>Format-Ayarları</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="26"/>
         <source>Goimports updates your Go import lines, adding missing ones and removing unreferenced ones.</source>
-        <translation>Goimports, import satırlarını günceller, eksik olanları ekler ve kullanılmayanları kaldırır.</translation>
+        <translation>Goimports, Go içe aktarma satırlarınızı günceller, eksik olanları ekler ve referans verilmeyenleri kaldırır.</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="29"/>
         <source>Enable update imports line, adding missing ones and removing unreferenced ones.</source>
-        <translation>Import satırlarını güncellemeyi etkinleştir.</translation>
+        <translation>Güncelleme içe aktarım satırını etkinleştirin, eksik olanları ekleyin ve referans verilmeyenleri kaldırın.</translation>
     </message>
     <message>
-        <source>Use goimports instead of gofmt, for code formatting</source>
-        <oldsource>Use goimports instead of gofmt,for code formatting</oldsource>
-        <translation>Kodu formatlamak için gofmt yerine goimports kullan</translation>
+        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="46"/>
+        <source>Synchronous</source>
+        <translation>Eşzamanlı</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="52"/>
+        <source>Synchronous code formatting</source>
+        <oldsource> Synchronous code formatting</oldsource>
+        <translation>Eşzamanlı kod biçimlendirme</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="61"/>
+        <source>Synchronous code formatting timeout in milliseconds (500ms or more):</source>
+        <translation>Milisaniye cinsinden eşzamanlı kod biçimlendirme zaman aşımı (500 ms veya daha fazla):</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="36"/>
-        <source>Enable sort imports of consecutive import lines in import blocks</source>
-        <oldsource>Import bloklarında ardışık import satırlarını etkinleştir</oldsource>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Use diff tool for faster formatting (requires diff program in PATH)</source>
-        <translation>Daha hızlı formatlama için diff programı kullan (PATH içinde diff yolu bulunmalıdır)</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="53"/>
-        <source>Synchronous</source>
-        <translation>Senkronize</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="59"/>
-        <source>Synchronous code formatting</source>
-        <oldsource> Synchronous code formatting</oldsource>
-        <translation>Senkronize kod formatlama</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="68"/>
-        <source>Synchronous code formatting timeout in milliseconds (500ms or more):</source>
-        <translation>Milisaniye cinsinden kod formatlama zamanaşımı (&gt;= 500ms):</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangfmt/golangfmtoption.ui" line="43"/>
         <source>Automatically format code when saving</source>
         <oldsource>When the editor is saved automatically gofmt</oldsource>
-        <translation>Kaydederken kodu otomatik olarak formatla</translation>
+        <translation>Kaydederken kodu otomatik olarak biçimlendir</translation>
     </message>
 </context>
 <context>
@@ -1925,30 +2698,108 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <location filename="src/plugins/golangfmt/golangfmtplugin.cpp" line="66"/>
         <source>Format Code</source>
         <oldsource>Format Code (goimports)</oldsource>
-        <translation>Kodu Formatla</translation>
+        <translation>Kodu Biçimlendir</translation>
     </message>
     <message>
         <location filename="src/plugins/golangfmt/golangfmtplugin.cpp" line="59"/>
         <source>Format Code (Adjusts Imports)</source>
-        <translation>Kodu Formatla (Importları ayarla)</translation>
+        <translation>Kodu Biçimlendir (İçe Aktarmaları Ayarlar)</translation>
+    </message>
+</context>
+<context>
+    <name>GolangPackageOption</name>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.cpp" line="304"/>
+        <source>Choose directory to add to GOPATH:</source>
+        <translation>GOPATH&apos;a eklenecek dizini seçin:</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="14"/>
+        <source>Manage GOPATH / Modules</source>
+        <translation>GOPATH modüllerini yönet</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="35"/>
+        <source>Go Modules</source>
+        <translation>Go Modülleri</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="78"/>
+        <source>Custom GONOPROXY</source>
+        <translation>Özel GONOPROXY</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="88"/>
+        <source>Custom GOPROXY</source>
+        <translation>Özel GOPROXY</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="95"/>
+        <source>Custom GO111MODULE</source>
+        <translation>Özel GO111MODULE</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="102"/>
+        <source>Custom GONOSUMDB</source>
+        <translation>Özel GONOSUMDB</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="109"/>
+        <source>Custom GOPRIVATE</source>
+        <translation>Özel GOPRIVATE</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="125"/>
+        <source>TextLabel</source>
+        <translation>Etiket</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="137"/>
+        <source>GOPATH</source>
+        <translation>GOPATH</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="163"/>
+        <source>Use System GOPATH</source>
+        <translation>Sistemde öntanımlı GOPATH kullan</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="186"/>
+        <source>Reload</source>
+        <translation>Yenile</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="210"/>
+        <source>Use Custom GOPATH (one per line)</source>
+        <translation>Özel  GOPATH kullan (her satırda bir adet)</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="233"/>
+        <source>Add Directory...</source>
+        <translation>Klasör Ekle...</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/golangpackageoption.ui" line="240"/>
+        <source>Clear</source>
+        <translation>Temizle</translation>
     </message>
 </context>
 <context>
     <name>GolangPresentEdit</name>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="64"/>
-        <source>Bölüm (s1)</source>
-        <translation>Kısım (s1)</translation>
+        <source>Section (s1)</source>
+        <translation>Bölüm (s1)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="67"/>
-        <source>Alt Bölüm (s2)</source>
-        <translation type="unfinished"></translation>
+        <source>Subsection (s2)</source>
+        <translation>Alt Bölüm (s2)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="70"/>
-        <source>Alt-Alt Bölüm (s3)</source>
-        <translation type="unfinished"></translation>
+        <source>Sub-subsection (s3)</source>
+        <translation>Alt Bölüm (s3)</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="73"/>
@@ -1963,85 +2814,93 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="79"/>
         <source>Inline Code</source>
-        <translation>Satıriçi Kod</translation>
+        <translation>Satır içi kod</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="82"/>
         <source>Switch Bullets</source>
-        <translation>Switch Noktaları</translation>
+        <translation>İzleri Değiştir</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="85"/>
         <source>Comment/Uncomment Selection</source>
-        <translation>Seçilen yorumları aç/kapat</translation>
+        <translation>Seçimi Yorum Satırı Yap/Kaldır</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="88"/>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="267"/>
         <source>Export HTML</source>
-        <translation>HTML Olarak Dışa Aktar</translation>
+        <translation>HTML olarak dışa aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="91"/>
         <source>Verify Present</source>
-        <translation>Durumu Doğrula</translation>
+        <translation>Sunumu Doğrula</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="256"/>
         <source>Present verify success</source>
-        <translation>Durum doğrulama başarılı</translation>
+        <translation>Mevcut doğrulama başarılı</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="258"/>
         <source>Present verify false</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut doğrulama başarısız</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpresent/golangpresentedit.cpp" line="310"/>
         <source>Export PDF</source>
-        <translation>PDF Olarak Dışa Aktar</translation>
+        <translation>PDF dışa aktar</translation>
+    </message>
+</context>
+<context>
+    <name>GolangSymbol</name>
+    <message>
+        <location filename="src/plugins/golangast/golangsymbol.cpp" line="62"/>
+        <source>Quick Open Symbol by Name</source>
+        <translation>Ada Göre Hızlı Sembol Aç</translation>
     </message>
 </context>
 <context>
     <name>GoplayBrowser</name>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="82"/>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="145"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="70"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="132"/>
         <source>Go Playground</source>
         <translation>Go Playground</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="84"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="72"/>
         <source>Run</source>
         <translation>Çalıştır</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="85"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="73"/>
         <source>Stop</source>
-        <translation>Dur</translation>
+        <translation>Durdur</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="86"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="74"/>
         <source>New</source>
         <translation>Yeni</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="87"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="75"/>
         <source>Load...</source>
         <translation>Yükle...</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="88"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="76"/>
         <source>Save...</source>
         <translation>Kaydet...</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="89"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="77"/>
         <source>Explore Folder</source>
-        <translation>Dizini Aç</translation>
+        <translation>Klasörleri Araştır</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="168"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="175"/>
         <source>Running...</source>
         <oldsource>Running...
 
@@ -2049,114 +2908,166 @@ Dosya içeriği diskten okunarak güncellensin mi?</translation>
         <translation>Çalışıyor...</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="192"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="195"/>
         <source>Error: %1.</source>
         <oldsource>
 Error: %1.</oldsource>
         <translation>Hata: %1.</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="194"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="197"/>
         <source>Success: %2.</source>
         <oldsource>
 Success: %2.</oldsource>
         <translation>Başarılı: %2.</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="244"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="247"/>
         <source>Load File</source>
         <translation>Dosya Yükle</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="244"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="247"/>
         <source>Select a file to load:</source>
-        <translation>Yüklenecek dosyayı seç:</translation>
+        <translation>Yüklenecek dosya seç:</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="260"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="263"/>
         <source>Save File</source>
-        <translation>Dosyayı Kaydet</translation>
+        <translation>Dosya Kaydet</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="260"/>
+        <location filename="src/plugins/golangplay/goplaybrowser.cpp" line="263"/>
         <source>New File Name:</source>
-        <translation>Yeni dosya adı:</translation>
+        <translation>Yeni Dosya Adı:</translation>
     </message>
 </context>
 <context>
     <name>HtmlPreview</name>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="71"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="72"/>
         <source>Page Style</source>
-        <translation>Sayfa Stili</translation>
+        <translation>Sayfa Yapısı</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="76"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="77"/>
         <source>Reload</source>
         <translation>Yenile</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="77"/>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="381"/>
-        <source>Export Html</source>
-        <translation>HTML Olarak Dışa Aktar</translation>
-    </message>
-    <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="78"/>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="413"/>
-        <source>Export PDF</source>
-        <translation>PDF Olarak Dışa Aktar</translation>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="382"/>
+        <source>Export Html</source>
+        <translation>HTML Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/htmlpreview.cpp" line="79"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="414"/>
+        <source>Export PDF</source>
+        <translation>PDF Dışa Aktar</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="80"/>
         <source>Print Preview</source>
         <translation>Baskı Önizleme</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="82"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="83"/>
         <source>Synchronize preview and code scrollbars</source>
-        <translation>Önizleme ve kod kaydırma çubuklarını senkronize et</translation>
+        <translation>Önizleme ve kod kaydırma çubuklarını senkronize edin</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="88"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="89"/>
         <source>Config</source>
-        <translation>Konfigürasyon</translation>
+        <translation>Ayar</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="168"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="169"/>
         <source>Plain HTML</source>
         <translation>Düz HTML</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="389"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="390"/>
         <source>Export Failed</source>
-        <translation>Dışa aktarma başarısız</translation>
+        <translation>Dışa Aktarım Başarısız</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="85"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="86"/>
         <source>Automatically display preview</source>
         <oldsource>Automatically Display Preview</oldsource>
-        <translation>Önizlemeyi otomatik olarak göster</translation>
+        <translation>Önizlemeyi otomatik göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="99"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="100"/>
         <source>HTML Preview</source>
         <oldsource>Html Preview</oldsource>
         <translation>HTML Önizleme</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/htmlpreview.cpp" line="390"/>
+        <location filename="src/plugins/markdown/htmlpreview.cpp" line="391"/>
         <source>Could not open %1 for writing!</source>
         <oldsource>Can not write file %1</oldsource>
-        <translation>%1 dosyası yazmak için açılamıyor!</translation>
+        <translation>%1 kaydetmek için açılamadı!</translation>
+    </message>
+</context>
+<context>
+    <name>ImageEditor</name>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="52"/>
+        <source>ZoomIn</source>
+        <translation>Büyüt</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="55"/>
+        <source>ZoomOut</source>
+        <translation>Küçült</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="58"/>
+        <source>Reset to original size</source>
+        <translation>Orjinal boyuta sıfırla</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="61"/>
+        <source>Fit to view</source>
+        <translation>Görüntüleyiciye sığdır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="64"/>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="247"/>
+        <source>Play movie</source>
+        <translation>Video Oynat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="68"/>
+        <source>Prev frame</source>
+        <translation>Önceki Çerçeve</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="72"/>
+        <source>Next frame</source>
+        <translation>Sonraki Çerçeve</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditor.cpp" line="244"/>
+        <source>Pause movie</source>
+        <translation>Duraklat</translation>
+    </message>
+</context>
+<context>
+    <name>ImageEditorFactory</name>
+    <message>
+        <location filename="src/plugins/imageeditor/imageeditorfactory.cpp" line="122"/>
+        <source>Image Viewer</source>
+        <translation>Resim görüntüleyici</translation>
     </message>
 </context>
 <context>
     <name>ImportPkgTip</name>
     <message>
-        <location filename="src/plugins/golangcode/golangcode.cpp" line="657"/>
+        <location filename="src/plugins/golangcode/golangcode.cpp" line="847"/>
         <source>warning, pkg not find, please enter to import :</source>
-        <translation>Uyarı: Pkg bulunamadı, içeri aktarmak için enter:</translation>
+        <translation>uyarı, paket bulunamıyor, lütfen içe aktarmak için girin:</translation>
     </message>
 </context>
 <context>
@@ -2164,131 +3075,131 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/jsonedit/jsonedit.cpp" line="51"/>
         <source>Verify</source>
-        <translation>Doğrula</translation>
+        <translation>Doğrulama</translation>
     </message>
     <message>
         <location filename="src/plugins/jsonedit/jsonedit.cpp" line="53"/>
         <source>Format Json</source>
-        <translation>Json Biçimlendir</translation>
+        <translation>Json Formatı</translation>
     </message>
     <message>
         <location filename="src/plugins/jsonedit/jsonedit.cpp" line="55"/>
         <source>Compact Json</source>
-        <translation>Sıkıştırılmış Json</translation>
+        <translation>Sıkılaştırılmış Json</translation>
     </message>
 </context>
 <context>
     <name>LiteApp</name>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="212"/>
+        <location filename="src/liteapp/liteapp.cpp" line="284"/>
         <source>Event Log</source>
         <translation>Olay Günlüğü</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="199"/>
+        <location filename="src/liteapp/liteapp.cpp" line="271"/>
         <source>Escape</source>
-        <translation>İptal</translation>
+        <translation>Vazgeç</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="635"/>
+        <location filename="src/liteapp/liteapp.cpp" line="756"/>
         <source>Close File</source>
         <translation>Dosyayı Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="638"/>
+        <location filename="src/liteapp/liteapp.cpp" line="759"/>
         <source>Close All Files</source>
-        <translation>Tüm Dosyaları Kapat</translation>
+        <translation>Bütün Dosyaları Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="648"/>
+        <location filename="src/liteapp/liteapp.cpp" line="769"/>
         <source>Save File</source>
         <translation>Dosyayı Kaydet</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="651"/>
+        <location filename="src/liteapp/liteapp.cpp" line="772"/>
         <source>Save File As...</source>
         <translation>Dosyayı Farklı Kaydet...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="654"/>
+        <location filename="src/liteapp/liteapp.cpp" line="775"/>
         <source>Save All Files</source>
-        <translation>Tüm Dosyaları Kaydet</translation>
+        <translation>Bütün Dosyaları Kaydet</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="641"/>
+        <location filename="src/liteapp/liteapp.cpp" line="762"/>
         <source>Open Project</source>
         <translation>Proje Aç</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="214"/>
+        <location filename="src/liteapp/liteapp.cpp" line="287"/>
         <source>Options</source>
-        <translation>Seçenekler</translation>
+        <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="612"/>
+        <location filename="src/liteapp/liteapp.cpp" line="733"/>
         <source>New...</source>
         <translation>Yeni...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="615"/>
+        <location filename="src/liteapp/liteapp.cpp" line="736"/>
         <source>Open File...</source>
         <translation>Dosya Aç...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="618"/>
+        <location filename="src/liteapp/liteapp.cpp" line="739"/>
         <source>Open Folder...</source>
-        <translation>Dizin Aç...</translation>
+        <translation>Klasör Aç...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="621"/>
+        <location filename="src/liteapp/liteapp.cpp" line="742"/>
         <source>Open Folder in New Window...</source>
-        <translation>Dizini Yeni Pencerede Aç...</translation>
+        <translation>Klasörü Yeni Pencerede Aç...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="626"/>
+        <location filename="src/liteapp/liteapp.cpp" line="747"/>
         <source>Close All Folders</source>
         <oldsource>Add Folder...</oldsource>
-        <translation>Tüm Dizinleri Kapat...</translation>
+        <translation>Bütün Klasörleri Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="629"/>
+        <location filename="src/liteapp/liteapp.cpp" line="750"/>
         <source>New Window</source>
         <translation>Yeni Pencere</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="632"/>
+        <location filename="src/liteapp/liteapp.cpp" line="753"/>
         <source>Close Window</source>
         <translation>Pencereyi Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="643"/>
+        <location filename="src/liteapp/liteapp.cpp" line="764"/>
         <source>Save Project</source>
         <translation>Projeyi Kaydet</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="645"/>
+        <location filename="src/liteapp/liteapp.cpp" line="766"/>
         <source>Close Project</source>
         <translation>Projeyi Kapat</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="657"/>
+        <location filename="src/liteapp/liteapp.cpp" line="778"/>
         <source>Exit</source>
         <translation>Çıkış</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="660"/>
+        <location filename="src/liteapp/liteapp.cpp" line="784"/>
         <source>Full Screen</source>
         <translation>Tam Ekran</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="664"/>
+        <location filename="src/liteapp/liteapp.cpp" line="788"/>
         <source>About LiteIDE</source>
         <translation>LiteIDE Hakkında</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteapp.cpp" line="670"/>
+        <location filename="src/liteapp/liteapp.cpp" line="794"/>
         <source>About Plugins</source>
-        <translation>Eklentiler Hakkında</translation>
+        <translation>Pluginler Hahhında</translation>
     </message>
 </context>
 <context>
@@ -2302,7 +3213,7 @@ Success: %2.</oldsource>
         <location filename="src/liteapp/liteappoption.ui" line="30"/>
         <source>Store [*]</source>
         <oldsource>Store</oldsource>
-        <translation>Depolama [*]</translation>
+        <translation>Kayıt [*]</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="57"/>
@@ -2310,137 +3221,199 @@ Success: %2.</oldsource>
         <translation>Dil:</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="239"/>
+        <location filename="src/liteapp/liteappoption.ui" line="144"/>
+        <source>Icon [*]</source>
+        <translation>İkon [*]</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="300"/>
+        <source>Reload files in session</source>
+        <translation>Oturumdaki dosyaları geri yükle</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="312"/>
         <source>Recent Files</source>
         <oldsource>Recent File</oldsource>
-        <translation>Son Kullanılan Dosyalar</translation>
+        <translation>Son kullanılanlar</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="245"/>
+        <location filename="src/liteapp/liteappoption.ui" line="318"/>
+        <location filename="src/liteapp/liteappoption.ui" line="357"/>
         <source>Max Count:</source>
         <oldsource>Max Recent:</oldsource>
-        <translation>En fazla dosya:</translation>
+        <translation>En Fazla:</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="128"/>
+        <location filename="src/liteapp/liteappoption.ui" line="229"/>
         <source>Monitoring files for modifications</source>
-        <translation>Dosyaların değişip değişmediğini gözlemle</translation>
+        <translation>Dosyaları değişikliğe karşı izleme</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="41"/>
-        <source>Ayarları lokal bir ini dosyasında sakla</source>
-        <translation type="unfinished"></translation>
+        <source>Store settings to local ini file</source>
+        <translation>Ayarları yerel ini dosyasında sakla</translation>
     </message>
     <message>
         <location filename="src/liteapp/liteappoption.ui" line="51"/>
-        <source>Arayüz [*]</source>
-        <translation type="unfinished"></translation>
+        <source>Interface [*]</source>
+        <translation>Arayüz [*]</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="67"/>
-        <source>Stil:</source>
-        <translation type="unfinished"></translation>
+        <location filename="src/liteapp/liteappoption.ui" line="74"/>
+        <source>Style:</source>
+        <translation>Stil:</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="96"/>
-        <source>Tema [*]</source>
-        <translation type="unfinished"></translation>
+        <location filename="src/liteapp/liteappoption.ui" line="84"/>
+        <source>Use tool window shortcuts</source>
+        <translation>Araç penceresi kısayollarını kullanın</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="134"/>
+        <location filename="src/liteapp/liteappoption.ui" line="112"/>
+        <source>Theme [*]</source>
+        <translation>Tema [*]</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="153"/>
+        <source>Fallback build-in icon library and liteapp/qrc/default</source>
+        <translation>Yedek yerleşik simge kitaplığı ve liteapp / qrc / default</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="156"/>
+        <source>Load the external file icon library</source>
+        <oldsource>Load custome icon from liteapp/qrc folder</oldsource>
+        <translation>Harici dosya simgesi kitaplığını yükleyin</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="184"/>
+        <source>Automatically save documents</source>
+        <translation>Dosyaları otomatik kaydet</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="190"/>
+        <source>Automatically save documents when application is idle</source>
+        <translation>Uygulama boştayken dosyaları otomatik olarak kaydedin</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="200"/>
+        <source>sec</source>
+        <translation>sn</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="235"/>
         <source>Auto reload or close editor buffer,if underlying file is modified/deleted.</source>
         <oldsource>Auto reload editor buffer from disk file,if underlying file is modified/deleted.</oldsource>
-        <translation>Açık dosya arkaplanda değişir/silinirse editör önbelleğini diskten okuyarak güncelle.</translation>
+        <translation>Ana dosya değiştirilirse / silinirse, düzenleyici arabelleğini otomatik olarak yeniden yükleyin veya kapatın.</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="163"/>
-        <location filename="src/liteapp/liteappoption.ui" line="169"/>
+        <location filename="src/liteapp/liteappoption.ui" line="263"/>
+        <location filename="src/liteapp/liteappoption.ui" line="269"/>
         <source>Session</source>
         <translation>Oturum</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="200"/>
-        <source>Reload folders on startup</source>
-        <translation>Açılışta dizinleri yeniden yükle</translation>
+        <location filename="src/liteapp/liteappoption.ui" line="325"/>
+        <source>0-99</source>
+        <translation>0-99</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="227"/>
-        <source>Reload files on startup</source>
-        <translation>Açılışta dosyaları yeniden yükle</translation>
+        <location filename="src/liteapp/liteappoption.ui" line="351"/>
+        <source>Editor Tabs</source>
+        <translation>Tab Düzenle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="306"/>
+        <location filename="src/liteapp/liteappoption.ui" line="364"/>
+        <source>10-999</source>
+        <translation>10-999</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="407"/>
         <source>Display</source>
         <translation>Ekran</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="312"/>
-        <source>Ekran [*]</source>
-        <translation type="unfinished"></translation>
+        <location filename="src/liteapp/liteappoption.ui" line="413"/>
+        <source>Display [*]</source>
+        <translation>Göster [*]</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="318"/>
+        <location filename="src/liteapp/liteappoption.ui" line="419"/>
         <source>Show splash screen on startup</source>
-        <translation>Açılışta splash penceresini göster</translation>
+        <translation>Aaçılışa başlangıç ekranını göster</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="325"/>
+        <location filename="src/liteapp/liteappoption.ui" line="426"/>
         <source>Show welcome page on startup</source>
-        <translation>Açılışta hoşgeldin sayfasını göster</translation>
+        <translation>Başlangıçta karşılama sayfasını göster</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="335"/>
+        <location filename="src/liteapp/liteappoption.ui" line="509"/>
+        <source>Editor</source>
+        <translation>Düzenleyici</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="515"/>
         <source>Editor tab [*]</source>
-        <translation>Sekmeler</translation>
+        <translation>Düzenleyici sekmesi [*]</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="341"/>
+        <location filename="src/liteapp/liteappoption.ui" line="521"/>
         <source>Show close buttons on each editor tab</source>
-        <translation>Editör sekmelerinde kapat butonunu göster</translation>
+        <translation>Editörün her sekmesinde kapatma butonu göster</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="348"/>
+        <location filename="src/liteapp/liteappoption.ui" line="528"/>
         <source>Enable mouse wheel navigation on tabs</source>
         <oldsource>Enable mouse wheel selected on tab</oldsource>
-        <translation>Fare tekerleği ile sekmeler arası gezintiyi etkinleştir</translation>
+        <translation>Sekmelerde fare tekerleği ile gezinmeyi etkinleştirin</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="358"/>
+        <location filename="src/liteapp/liteappoption.ui" line="436"/>
         <source>Toolbar Icon Size [*]</source>
-        <translation>Araç Çubuğu İkonları</translation>
+        <translation>Araç Çubuğu İkon Boyutu</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="431"/>
+        <location filename="src/liteapp/liteappoption.ui" line="538"/>
+        <source>Editor navigate</source>
+        <translation>Düzenleyicide gezinme</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="544"/>
+        <source>Enable mouse extra &apos;Back&apos; button and &apos;Forward&apos; button for go back and forward</source>
+        <translation>Geri ve ileri gitmek için farenin ekstra &apos;Geri&apos; düğmesini ve &apos;İleri&apos; düğmesini etkinleştirin</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.ui" line="568"/>
         <source>Keyboard</source>
         <translation>Klavye</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="437"/>
+        <location filename="src/liteapp/liteappoption.ui" line="574"/>
         <source>Format: {Ctrl+B},{Ctrl+Shift+B},{Ctrl+K,Ctrl+U},{Ctrl+Shift+Z;Ctrl+Y}</source>
         <translation>Format: {Ctrl+B},{Ctrl+Shift+B},{Ctrl+K,Ctrl+U},{Ctrl+Shift+Z;Ctrl+Y}</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="449"/>
+        <location filename="src/liteapp/liteappoption.ui" line="586"/>
         <source>Hide standard commands</source>
         <translation>Standart komutları gizle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="456"/>
+        <location filename="src/liteapp/liteappoption.ui" line="593"/>
         <source>Reset</source>
         <translation>Sıfırla</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="463"/>
+        <location filename="src/liteapp/liteappoption.ui" line="600"/>
         <source>Reset All</source>
         <translation>Tümünü Sıfırla</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="483"/>
+        <location filename="src/liteapp/liteappoption.ui" line="620"/>
         <source>Import...</source>
         <translation>İçe Aktar...</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="490"/>
+        <location filename="src/liteapp/liteappoption.ui" line="627"/>
         <source>Export...</source>
         <translation>Dışa Aktar...</translation>
     </message>
@@ -2450,243 +3423,218 @@ Success: %2.</oldsource>
         <translation>Genel</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="102"/>
+        <location filename="src/liteapp/liteappoption.ui" line="118"/>
         <source>Theme:</source>
         <translation>Tema:</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.ui" line="175"/>
+        <location filename="src/liteapp/liteappoption.ui" line="275"/>
         <source>Reload session on startup</source>
         <oldsource>Auto load last session</oldsource>
-        <translation>Açılışta oturumu yeniden yükle</translation>
+        <translation>Açılışta oturumu geri yükle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="85"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="97"/>
         <source>SideBarStyle</source>
-        <translation>Sidebar Stili</translation>
+        <translation>Araç Çubuğu Stili</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="86"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="98"/>
         <source>SplitterStyle</source>
-        <translation>Ayıraç Stili</translation>
+        <translation>Bölme Stili</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="140"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="82"/>
         <source>Command</source>
         <translation>Komut</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="141"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="83"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="142"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="84"/>
         <source>Shortcuts</source>
-        <translation>Kısayollar</translation>
+        <translation>Kısayol</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="143"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="85"/>
+        <source>NativeText</source>
+        <translation>Yerel Metin</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/liteappoption.cpp" line="86"/>
         <source>Standard</source>
         <translation>Standart</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="412"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="506"/>
         <source>Import Keyboard Mapping Scheme</source>
-        <translation>Klavye kısayol şemasını içe aktar</translation>
+        <translation>Klavye Eşleme Şemasını İçe Aktar</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="412"/>
-        <location filename="src/liteapp/liteappoption.cpp" line="446"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="506"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="540"/>
         <source>Keyboard Mapping Scheme (%1)</source>
-        <translation>Klavye Kısayol Şeması (%1)</translation>
+        <translation>Klavye Eşleme Şeması (%1)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="419"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="513"/>
         <source>Could not read scheme from %1!</source>
-        <translation>%1 yolundaki şema okunamıyor!</translation>
+        <translation>(%1) Klavye Eşleme Şeması okunamadı!</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="446"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="540"/>
         <source>Export Keyboard Mapping Scheme</source>
-        <translation>Klavye kısayol şemasını dışarı aktar</translation>
+        <translation>Klavye Eşleme Şemasını Dışa Aktar</translation>
     </message>
     <message>
-        <location filename="src/liteapp/liteappoption.cpp" line="457"/>
+        <location filename="src/liteapp/liteappoption.cpp" line="551"/>
         <source>Could not write scheme to %1!</source>
-        <translation>Şema %1 dosyasına yazılamıyor!</translation>
+        <translation>Klavye Eşleme Şeması (%1) yazılamadı!</translation>
     </message>
 </context>
 <context>
     <name>LiteBuild</name>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="139"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="141"/>
         <source>Build Toolbar</source>
         <translation>Derleme Araç Çubuğu</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="144"/>
-        <source>&amp;Build</source>
-        <translation>Derle</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="150"/>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="154"/>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="158"/>
-        <source>Name</source>
-        <translation>İsim</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="151"/>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="155"/>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="159"/>
-        <source>Value</source>
-        <translation>Değer</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="163"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="149"/>
         <source>Build Configuration...</source>
         <oldsource>Build Config</oldsource>
-        <translation>Derleme ayarları...</translation>
+        <translation>Derleme Ayarları...</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="177"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="167"/>
         <source>Stop Action</source>
-        <translation>Eylemi Durdur</translation>
+        <translation>İşlemi Durdur</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="171"/>
+        <source>Clear Output</source>
+        <oldsource>Clear All</oldsource>
+        <translation>Çıktıları Temizle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="175"/>
+        <source>Execute File</source>
+        <translation>Dosyayı Çalıştır</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="178"/>
+        <source>Debug File</source>
+        <translation>Dosya Hata Ayıklaması</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuild.cpp" line="181"/>
-        <source>Clear Output</source>
-        <oldsource>Clear All</oldsource>
-        <translation>Çıktıyı Temizle</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="185"/>
-        <source>Execute File</source>
-        <translation>Dosya Çalıştır</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="188"/>
         <source>Lock Build Path</source>
+        <oldsource>Lock Go Build Path</oldsource>
         <translation>Derleme Yolunu Kilitle</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="189"/>
-        <source>Go Build</source>
-        <translation>Go Build</translation>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="183"/>
+        <source>Build Path Configuration</source>
+        <oldsource>Go Build Configuration</oldsource>
+        <translation>Derleme Yolu Ayarları</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="191"/>
-        <source>Go Install</source>
-        <translation>Go Install</translation>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="229"/>
+        <source>Use godoc View</source>
+        <translation>godoc görünümünü kullanın</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="193"/>
-        <source>Go Test</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="195"/>
-        <source>Go Clean</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="203"/>
-        <source>Go Fmt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="216"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="286"/>
         <source>Line Wrap</source>
         <translation>Satır Kaydırma</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="220"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="290"/>
         <source>Auto Clear</source>
-        <translation>Otomatik Temizle</translation>
+        <translation>Otomatik temizleme</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="231"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="294"/>
+        <source>Automatic positioning cursor</source>
+        <translation>Otomatik imleç konumlandırma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="309"/>
         <source>Setup</source>
-        <translation>Kurulum</translation>
+        <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="238"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="317"/>
         <source>Build Output</source>
         <oldsource>Build</oldsource>
         <translation>Derleme Çıktısı</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="591"/>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="597"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="730"/>
         <source>Current environment change id &quot;%1&quot;</source>
-        <translation>Mevcut çalışma ortamı değişilik no &quot;%1&quot;</translation>
+        <translation>Mevcut ortam değişiklik kimliği &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="927"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1144"/>
         <source>Lock Build</source>
         <oldsource>Lock Build: %1</oldsource>
-        <translation>Derlemeyi kilitle</translation>
+        <translation>Derlemeyi Kilitle</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1266"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1482"/>
         <source>Error: %1.</source>
         <oldsource>Error: %1.
 </oldsource>
         <translation>Hata: %1.</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1269"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1485"/>
         <source>Command exited with code %1.</source>
-        <translation>Komutun çalışması %1 koduyla sonlandı.</translation>
+        <translation>Komut sonlandırma durumu %1.</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1271"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1487"/>
         <source>Success: %1.</source>
-        <oldsource>Başarılı: %1.
+        <oldsource>Success: %1.
 </oldsource>
-        <translation type="unfinished">Erfolg: %1.</translation>
+        <translation>Başarılı: %1.</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1307"/>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1360"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1536"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1588"/>
         <source>A process is currently running.  Stop the current action first.</source>
         <oldsource>A process is currently running.  Stop the current action first.
 </oldsource>
-        <translation>Şu an bir proses zaten çalışıyor.. Önce bu eylemi durdurun.</translation>
+        <translation>Şu anda bir işlem çalışıyor. Önce mevcut eylemi durdurun.</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1353"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1574"/>
         <source>Killing current process...</source>
         <oldsource>Killing current process...
 </oldsource>
-        <translation>Mevcut proses öldürülüyor...</translation>
+        <translation>Mevcut işlem sonlandırılıyor...</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1356"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1584"/>
         <source>Failed to terminate the existing process!</source>
         <oldsource>Failed to terminate the existing process!
 </oldsource>
-        <translation>Mevcut prosesin durdurulması başarısız!</translation>
+        <translation>Mevcut işlem sonlandırılamadı!</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1454"/>
-        <source>&gt; Could not parse action &apos;%1&apos;</source>
-        <oldsource>&gt; Could not parse action &apos;%1&apos;
-</oldsource>
-        <translation>&gt; Eylem &apos;%1&apos; okunamıyor</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1500"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1794"/>
         <source>Started process successfully</source>
         <oldsource>Started process successfully
 </oldsource>
-        <translation>Proses başlatma başarılı</translation>
+        <translation>İşlem başarıyla başlatıldı</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuild.cpp" line="1500"/>
+        <location filename="src/plugins/litebuild/litebuild.cpp" line="1794"/>
         <source>Failed to start process</source>
-        <translation>Proses başlatılamıyor</translation>
+        <translation>İşlem başlatma hatası</translation>
     </message>
 </context>
 <context>
@@ -2694,124 +3642,114 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/litebuild/litebuildoption.ui" line="14"/>
         <source>Form</source>
-        <translation>Forum</translation>
+        <translation>Form</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuildoption.ui" line="20"/>
         <source>Recheck Go installation when changing environments</source>
         <oldsource>Recheck go env if enviroment changed</oldsource>
-        <translation>Çalışma ortamı değişikliğinde Go kurulumunu kontrol et</translation>
+        <translation>Ortam değişkenleri değiştirilince Go kurulumunu tekrar kontrol et</translation>
     </message>
     <message>
         <location filename="src/plugins/litebuild/litebuildoption.ui" line="27"/>
         <source>Build command configuration files [*]</source>
         <oldsource>Build command configuration files:</oldsource>
-        <translation>Komut ayarları dosyalarını derle:</translation>
+        <translation>Komutla yapılandırma dosyalarını oluşturun [*]</translation>
     </message>
 </context>
 <context>
     <name>LiteBuildPlugin</name>
     <message>
-        <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="101"/>
+        <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="102"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="104"/>
+        <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="105"/>
         <source>Execute:</source>
         <oldsource>Exec:</oldsource>
         <translation>Çalıştır:</translation>
     </message>
     <message>
-        <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="111"/>
+        <location filename="src/plugins/litebuild/litebuildplugin.cpp" line="112"/>
         <source>Execute File</source>
         <oldsource>Execute</oldsource>
-        <translation>Dosyayı Çalıştır</translation>
+        <translation>Dosya Çalıştır</translation>
     </message>
 </context>
 <context>
     <name>LiteDebug</name>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="116"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="114"/>
         <source>Stop</source>
         <translation>Dur</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="73"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="75"/>
         <source>Clear</source>
         <translation>Temizle</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="113"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="111"/>
         <source>Continue</source>
-        <translation>Devam et</translation>
+        <translation>Devam</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="119"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="117"/>
         <source>Show Current Line</source>
-        <translation>Mevcut Satırı Göster</translation>
+        <translation>Geçerli Satırı Göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="194"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="189"/>
         <source>Debug Output</source>
         <oldsource>Debug</oldsource>
         <translation>Hata Ayıklama Çıktısı</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="103"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="105"/>
         <source>Start Debugging External Application...</source>
         <oldsource>Start Debugging External Application</oldsource>
-        <translation>Hata Ayıklamayı Harici Uygulamada Başlat...</translation>
+        <translation>Dış Uygulama Hata Ayıklaması...</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="91"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="93"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="106"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="108"/>
         <source>Start Debugging</source>
         <translation>Hata Ayıklamaya Başla</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="109"/>
-        <source>Start Debugging Tests</source>
-        <translation>Hata Ayıklama Testlerine Başla</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="122"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="120"/>
         <source>Step Into</source>
-        <translation>İçine Adım</translation>
+        <translation>Adım İleri</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="125"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="123"/>
         <source>Step Over</source>
-        <translation>Üzerinden Atla</translation>
+        <translation>Adım İleri</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="128"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="126"/>
         <source>Step Out</source>
-        <translation>Dışa Adım</translation>
+        <translation>Dışarı Çık</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="131"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="129"/>
         <source>Run to Line</source>
-        <translation>Satıra kadar Çalış</translation>
+        <translation>Satıra kadar çalıştır</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="134"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="132"/>
         <source>Insert/Remove Breakpoint</source>
-        <translation>Kesme noktası ekle/kaldır</translation>
+        <translation>Kesme Ekle/Kaldır</translation>
     </message>
     <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="137"/>
+        <location filename="src/plugins/litedebug/litedebug.cpp" line="135"/>
         <source>Remove All Breakpoints</source>
-        <translation>Tüm Kesme Noktalarını Kaldır</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/litedebug/litedebug.cpp" line="156"/>
-        <source>&amp;Debug</source>
-        <translation>&amp;Hata Ayıkla</translation>
+        <translation>Tüm Kesmeleri Kaldır</translation>
     </message>
 </context>
 <context>
@@ -2828,9 +3766,9 @@ Success: %2.</oldsource>
     </message>
     <message>
         <location filename="src/plugins/litedebug/litedebugoption.ui" line="26"/>
-        <source>Rebuild before debugging</source>
-        <oldsource>Debug before rebuild</oldsource>
-        <translation>Hata ayıklamadan önce yeniden derle</translation>
+        <source>Automatically insert breakpoint main.main when debugging</source>
+        <oldsource>Automatically add breakpoint main.main when debugging</oldsource>
+        <translation>Hata ayıklamada main için otomatik olarak breakpoint yerleştir</translation>
     </message>
 </context>
 <context>
@@ -2845,301 +3783,419 @@ Success: %2.</oldsource>
 <context>
     <name>LiteDoc</name>
     <message>
-        <location filename="src/plugins/welcome/litedoc.cpp" line="63"/>
+        <location filename="src/plugins/welcome/litedoc.cpp" line="64"/>
         <source>LiteIDE Documentation</source>
         <oldsource>LiteIDE Document Browser</oldsource>
-        <translation>LiteIDE Dökümanları</translation>
+        <translation>LiteIDE Dökümantasyonu</translation>
     </message>
 </context>
 <context>
     <name>LiteEditor</name>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="241"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="254"/>
         <source>Undo</source>
-        <translation>Geri Al</translation>
+        <translation>Geri al</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="244"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="257"/>
         <source>Redo</source>
-        <translation>Yeniden Yap</translation>
+        <translation>Yinele</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="247"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="260"/>
         <source>Cut</source>
         <translation>Kes</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="250"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="263"/>
         <source>Copy</source>
-        <translation>Kopyala</translation>
+        <translation>Kplyala</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="253"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="266"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="256"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="268"/>
         <source>Select All</source>
         <translation>Tümünü Seç</translation>
     </message>
     <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="301"/>
+        <source>Go to Doc Start</source>
+        <translation>Döküman Başına Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="305"/>
+        <source>Go to Doc End</source>
+        <translation>Döküman Sonuna Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="309"/>
+        <source>Go to Line Start</source>
+        <translation>Satır Başına Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="313"/>
+        <source>Go to Line End</source>
+        <translation>Satırın Sonuna Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="317"/>
+        <source>Go to Previous Line</source>
+        <translation>Önceki Satıra Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="321"/>
+        <source>Go to Next Line</source>
+        <translation>Sonraki Satır Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="325"/>
+        <source>Go to Previous Character</source>
+        <translation>Önceki Karaktere Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="329"/>
+        <source>Go to Next Charater</source>
+        <translation>Sonraki Karaktere Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="333"/>
+        <source>Go to Previous Word</source>
+        <translation>Önceki Kelimeye Git</translation>
+    </message>
+    <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="337"/>
-        <source>Word Wrap (MimeType)</source>
-        <translation>Satır Kaydırma (MimeTipi)</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="348"/>
-        <source>Toggle Comment</source>
-        <translation>Yorumu Evir</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="351"/>
-        <source>Toggle Block Commnet</source>
-        <translation>Blok Yorumu Evir</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="354"/>
-        <source>Auto-indent Selection</source>
-        <translation>Seçimi Otomatik Hizala</translation>
+        <source>Go to Next Word</source>
+        <translation>Sonraki Kelimeye Git</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="358"/>
+        <source>Go to Line</source>
+        <translation>Satır Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="361"/>
+        <source>File is readonly</source>
+        <translation>Dosya Saltokunur</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="364"/>
+        <source>File is writable</source>
+        <translation>Dosya Yazılabilir</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="404"/>
+        <source>Line Wrap (MimeType)</source>
+        <oldsource>Word Wrap (MimeType)</oldsource>
+        <translation>Satır Kaydırma (Mime Türü)</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="415"/>
+        <source>Toggle Comment</source>
+        <translation>Yorumu Aç / Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="418"/>
+        <source>Toggle Block Commnet</source>
+        <translation>Blok Yorumunu Aç / Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="421"/>
+        <source>Auto-indent Selection</source>
+        <translation>Otomatik girinti Seçimi</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="425"/>
         <source>Tab To Spaces (MimeType)</source>
-        <translation>Tab-Boşluk Dönüşümü (MimeTipi)</translation>
+        <translation>Boşluklara Sekme (Mime Türü)</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="362"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="429"/>
         <source>Line End Windows (\r\n)</source>
-        <translation>Windows satır sonu (\r\n)</translation>
+        <translation>Satır Sonu Windows (\r\n)</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="366"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="433"/>
         <source>Line End Unix (\n)</source>
-        <translation>Unix satır sonu (\n)</translation>
+        <translation>Satır Sonu Unix (\n)</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="370"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="437"/>
         <source>Visualize Whitespace (Global)</source>
-        <translation>Boşlukları Görünür Yap (Genel)</translation>
+        <translation>Beyaz Alanı Görselleştir (Global)</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="377"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="444"/>
         <source>Move Line Up</source>
         <translation>Satırı Yukarı Taşı</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="380"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="447"/>
         <source>Move Line Down</source>
         <translation>Satırı Aşağı Taşı</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="383"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="450"/>
         <source>Copy Line Up</source>
         <translation>Satırı Yukarı Kopyala</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="386"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="453"/>
         <source>Copy Line Down</source>
         <translation>Satırı Aşağı Kopyala</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="389"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="456"/>
         <source>Join Lines</source>
         <translation>Satırları Birleştir</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="544"/>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="606"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="459"/>
+        <source>Title Case</source>
+        <translation>Baş Harfler</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="463"/>
+        <source>Upper Case</source>
+        <translation>Büyük Harfler</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="467"/>
+        <source>Lower Case</source>
+        <translation>Küçük Harfler</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="471"/>
+        <source>Swap Case</source>
+        <translation>Kılıf Takası</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="475"/>
+        <source>Tab To Spaces</source>
+        <translation>Boşluklu Sekme</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="479"/>
+        <source>Spaces To Tab</source>
+        <translation>Tab boşlokları</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="645"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="733"/>
         <source>Advanced</source>
         <translation>Gelişmiş</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="574"/>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="629"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="671"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="751"/>
+        <source>Goto</source>
+        <translation>Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="696"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="774"/>
+        <source>Convert Tab</source>
+        <translation>Tab Dönüştürme</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="700"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="778"/>
         <source>Code Folding</source>
-        <translation>Kod Katlama</translation>
+        <translation>Kodu Kapat</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="981"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="690"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="768"/>
+        <source>Convert Case</source>
+        <translation>Karakter Dönüştürme</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1199"/>
         <source>Export HTML</source>
-        <translation>HTML Olarak Dışa Aktar</translation>
+        <translation>HTML Dışa Aktar</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="989"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1207"/>
         <source>Export Failed</source>
-        <translation>Dışa Aktarma Başarısız</translation>
+        <translation>Dışarı Aktarılamadı</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="990"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1208"/>
         <source>Could not open %1 for writing.</source>
-        <translation>%1 dosyası yazmak için açılamıyor.</translation>
+        <translation>%1 yazmak için açılamadı.</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1009"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1227"/>
         <source>Export PDF</source>
-        <translation>PDF Olarak Dışa Aktar</translation>
+        <translation>PDF Dışa Aktar</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1034"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1252"/>
         <source>Print Document</source>
-        <translation>Dökümanı Yazdır</translation>
+        <translation>Dosya Yazdır</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="263"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="286"/>
         <source>Print Preview...</source>
         <oldsource>Print Preview Document</oldsource>
-        <translation>Döküman Baskı Önizleme...</translation>
+        <translation>Baskı-Önizleme...</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="259"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="282"/>
         <source>Export HTML...</source>
-        <translation>HTML Olarak Dışa Aktar...</translation>
+        <translation>HTML Dışa AktarL...</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="261"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="284"/>
         <source>Export PDF...</source>
-        <translation>PDF Olarak Dışa Aktar...</translation>
+        <translation>PDF Dışa Aktar...</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="262"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="285"/>
         <source>Print...</source>
         <translation>Yazdır...</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="265"/>
-        <source>Go To Previous Block</source>
-        <oldsource>Goto Previous Block</oldsource>
-        <translation>Bir Önceki Bloğa Git</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="272"/>
-        <source>Select Block</source>
-        <translation>Bloğu Seç</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="275"/>
-        <source>Go To Matching Brace</source>
-        <oldsource>Goto Match Brace</oldsource>
-        <translation>Eşleşen Paranteze Git</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="278"/>
-        <source>Fold</source>
-        <translation>Katla</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="281"/>
-        <source>Unfold</source>
-        <translation>Göster</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="284"/>
-        <source>Fold All</source>
-        <translation>Tümünü Katla</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="287"/>
-        <source>Unfold All</source>
-        <translation>Tümünü Göster</translation>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="288"/>
+        <source>Go to Previous Block</source>
+        <oldsource>Go To Previous Block</oldsource>
+        <translation>Önceki Bloğa Git</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditor.cpp" line="295"/>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1093"/>
+        <source>Select Block</source>
+        <translation>Blok Seç</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="298"/>
+        <source>Go to Matching Brace</source>
+        <oldsource>Go To Matching Brace</oldsource>
+        <translation>Eşleşen Ayraç&apos;a git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="341"/>
+        <source>Fold</source>
+        <translation>Kapa</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="344"/>
+        <source>Unfold</source>
+        <translation>Aç</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="347"/>
+        <source>Fold All</source>
+        <translation>Tümünü Kapa</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="350"/>
+        <source>Unfold All</source>
+        <translation>Tümünü Aç</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1327"/>
         <source>Go To Line</source>
         <oldsource>Goto Line</oldsource>
         <translation>Satıra Git</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="298"/>
-        <source>Locked</source>
-        <translation>Kilitli</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="301"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="368"/>
         <source>Duplicate</source>
-        <translation>Kopyasını Al</translation>
+        <translation>Kopya Oluştur</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="305"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="372"/>
         <source>Delete Line</source>
-        <translation>Satırı Sil</translation>
+        <translation>Satır Sil</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="309"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="376"/>
         <source>Copy Line</source>
-        <translation>Satırı Kopyala</translation>
+        <translation>Satır Koplaya</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="313"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="380"/>
         <source>Cut Line</source>
         <translation>Satırı Kes</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="317"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="384"/>
         <source>Insert Line Before</source>
-        <translation>Önüne satır ekle</translation>
+        <translation>Önüne Çizgi Ekle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="321"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="388"/>
         <source>Insert Line After</source>
-        <translation>Arkasına satır ekle</translation>
+        <translation>Arkasına Çizgi Ekle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="325"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="392"/>
         <source>Increase Font Size</source>
-        <translation>Yazıtipini Büyüt</translation>
+        <translation>Yazı Tipi Boyutunu Arttır</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="328"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="395"/>
         <source>Decrease Font Size</source>
-        <translation>Yazıtipini Küçült</translation>
+        <translation>Yazı Tipi Boyutunu Küçült</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="331"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="398"/>
         <source>Reset Font Size</source>
-        <translation>Yazıtipi Boyutunu Sıfırla</translation>
+        <translation>Yazı Tipi Boyutunu Sıfırla</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="334"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="401"/>
         <source>Clean Whitespace</source>
-        <translation>Boşlukları Temizle</translation>
+        <translation>Boşlukları temizle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="341"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="408"/>
         <source>Code Complete</source>
-        <translation>Kod tamamlama</translation>
+        <translation>Kod Tamamlandı</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="704"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="706"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="784"/>
+        <source>Settings</source>
+        <oldsource>File Setup</oldsource>
+        <translation>Ayarlar</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="892"/>
         <source>Reload File</source>
-        <translation>Dosyayı Yenile</translation>
+        <translation>Dosyayı Tekrar Yükle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1051"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1269"/>
         <source>Do you want to permanently discard unsaved modifications and reload %1?</source>
-        <translation>Kaydedilmemiş değişiklikleri gözardı edip %1 dosyasını yeniden yüklemek istediğinize emin misiniz?</translation>
+        <translation>Kaydedilmemiş değişiklikleri kalıcı olarak silmek ve%1&apos;i yeniden yüklemek istiyor musunuz?</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="268"/>
-        <source>Go To Next Block</source>
-        <oldsource>Goto Next Block</oldsource>
-        <translation>Bir Sonraki Bloğa Git</translation>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="291"/>
+        <source>Go to Next Block</source>
+        <oldsource>Go To Next Block</oldsource>
+        <translation>Sonraki Bloğa Git</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="580"/>
-        <source>Setup</source>
-        <translation>Kurulum</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1081"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1301"/>
         <source>ReadOnly</source>
         <translation>SaltOkunur</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1093"/>
+        <location filename="src/plugins/liteeditor/liteeditor.cpp" line="1327"/>
         <source>Line: </source>
         <translation>Satır: </translation>
+    </message>
+</context>
+<context>
+    <name>LiteEditorFileFactory</name>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditorfilefactory.cpp" line="203"/>
+        <source>Text Editor</source>
+        <translation>Metin Düzenleyici</translation>
     </message>
 </context>
 <context>
@@ -3150,176 +4206,225 @@ Success: %2.</oldsource>
         <translation>Form</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="349"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="408"/>
         <source>Load File</source>
-        <translation>Dosya Yükle</translation>
+        <translation>Dosyayı Yükle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="355"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="414"/>
         <source>Check and convert no printable char to &apos;.&apos;</source>
-        <translation>Görüntülenmeyen karakterleri yakala ve &apos;.&apos; ile değiştir</translation>
+        <translation>Yazdırılamayan karakteri kontrol edin ve &quot;.&quot; yap</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="30"/>
         <source>Font</source>
-        <translation>Yazıtipi</translation>
+        <translation>Font</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="24"/>
         <source>Font &amp;&amp; Colors</source>
-        <translation type="unfinished">Yazıtipi &amp;&amp; Renkler</translation>
+        <translation>Font &amp;&amp; Renkler</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="36"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="38"/>
         <source>Family:</source>
-        <translation>Aile:</translation>
+        <translation>Küme:</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="53"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="48"/>
+        <source>Show Monospace Font</source>
+        <translation>Tek Aralıklı Yazı Tipini Göster</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="72"/>
         <source>Size:</source>
-        <translation>Boyut:</translation>
+        <translation>Büyüklük:</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="70"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="92"/>
         <source>Zoom:</source>
         <translation>Zoom:</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="77"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="99"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="96"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="118"/>
         <source>Antialias</source>
-        <translation>Yumuşak kenarlar</translation>
+        <translation>Antialias</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="119"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="138"/>
+        <source>Restore Default Font</source>
+        <translation>Varsayılan Yazı Tipini Geri Yükle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="150"/>
         <source>Editor Color Scheme</source>
         <oldsource>ColorStyle Scheme</oldsource>
-        <translation>Editör Renk Şeması</translation>
+        <translation>Editörün Renk Şeması</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="127"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="158"/>
         <source>File:</source>
         <translation>Dosya:</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="144"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="175"/>
         <source>Edit</source>
-        <translation>Düzen</translation>
+        <translation>Düzenle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="189"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="220"/>
         <source>Syntax Auto-completion</source>
         <oldsource>Auto complete brackets</oldsource>
-        <translation>Sözdizimini Otomatik Tamamlama</translation>
+        <translation>Sözdizimi Otomatik Tamamlama</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="312"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="302"/>
+        <source>Fuzzy code completion</source>
+        <translation>Belirsiz kod tamamlama</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="350"/>
+        <source>Clean completion cache when saving files</source>
+        <translation>Dosyaları kaydederken tamamlama önbelleğini temizleyin</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="357"/>
         <source>Clean whitespace when saving files</source>
-        <translation>Dosyaları kaydederken gereksiz boşlukları sil</translation>
+        <translation>Dosyaları kaydederken boşlukları temizleyin</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="319"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="364"/>
         <source>Enable scroll wheel zooming</source>
-        <translation>Fare terkerleği ile zoom etkin</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="378"/>
-        <source>Display VisualizeWhitespace</source>
-        <translation>Boşlukları Görselleştir</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="392"/>
-        <source>Word wrap by default</source>
-        <translation>Varsayılan olarak satırları kaydır</translation>
+        <translation>Kaydırma tekerleği ile yakınlaştırmayi etkinleştir</translation>
     </message>
     <message>
         <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="371"/>
+        <source>Add copied text into the clipboard as HTML</source>
+        <translation>Kopyalanan metni panoya HTML olarak ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="378"/>
+        <source>Allow vertical scrolling to the last line [*]</source>
+        <translation>Son satıra [*] dikey kaydırmaya izin ver</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="437"/>
+        <source>Display VisualizeWhitespace</source>
+        <translation>Beyaz Alanı Görselleştir</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="451"/>
+        <source>Word wrap by default</source>
+        <translation>Varsayılan olarak kelime kaydırma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="430"/>
         <source>Display code fold</source>
-        <translation>Kod katlamayı göster</translation>
+        <translation>Kod katlamalarını göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="450"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="509"/>
         <source>Display offset position</source>
-        <translation>Kenar boşluğu konumunu göster</translation>
+        <translation>Ofset konumunu göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="474"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="533"/>
         <source>File Types</source>
-        <translation>Dosya Tipleri</translation>
+        <translation>Dosya Türleri</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="183"/>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="258"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="214"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="289"/>
         <source>Behavior</source>
-        <translation>Davranış</translation>
+        <translation>Davranışı</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="385"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="444"/>
         <source>Display EOF</source>
-        <translation>Satır sonu (EOF) karakterini göster</translation>
+        <translation>Dosyasonunu (EOF) göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="399"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="458"/>
         <source>Display line numbers</source>
         <translation>Satır numaralarını göster</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="406"/>
-        <source>Display indent guide </source>
-        <translation>Hizalama çizgisini göster</translation>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="465"/>
+        <source>Display indent guide</source>
+        <oldsource>Display indent guide </oldsource>
+        <translation>Girinti kılavuzunu görüntüle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="415"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="474"/>
         <source>Display right margin at column</source>
-        <translation>Sağ marjini göster</translation>
+        <translation>Sütunda sağ kenar boşluğunu görüntüle</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="264"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="295"/>
         <source>Automatic indentation</source>
         <oldsource>Enable automatic indentation</oldsource>
-        <translation>Otomatik hizala</translation>
+        <translation>Otomatik girinti</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="271"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="309"/>
         <source>Case sensitive code completion</source>
         <oldsource>Completer case sensitive</oldsource>
-        <translation>Kod tamamlarken Küçük/BÜYÜK harfe duyarlı ol</translation>
+        <translation>Büyük / küçük harfe duyarlı kod tamamlama</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="280"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="318"/>
         <source>Code completion prefix length:</source>
         <oldsource>Word Complete Prefix Length</oldsource>
-        <translation>Kod tamamlama için karakter sayısı:</translation>
+        <translation>Kod tamamlama önek uzunluğu:</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="343"/>
-        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="365"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="402"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.ui" line="424"/>
         <source>Display</source>
-        <translation>Görünüm</translation>
+        <translation>Görüntüleme</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="141"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="74"/>
         <source>MIME Type</source>
-        <translation>MIME-Tipi</translation>
+        <translation>MIME Türü</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="142"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="75"/>
         <source>Tab Width</source>
-        <translation>Tab Genişliği</translation>
+        <translation>Tab-Genişliği</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="143"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="76"/>
         <source>Tab To Spaces</source>
-        <translation>Tab-Boşluk Dönüşümü</translation>
+        <translation>Sekmeleri boşluk işaretine dönüştür</translation>
     </message>
     <message>
-        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="144"/>
+        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="78"/>
         <source>File Extensions</source>
         <translation>Dosya Uzantıları</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditoroption.cpp" line="77"/>
+        <source>Custom Extensions</source>
+        <translation>Özel Uzantılar</translation>
+    </message>
+</context>
+<context>
+    <name>LiteEditorPlugin</name>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditorplugin.cpp" line="71"/>
+        <source>Edit ToolBar</source>
+        <translation>Araç Çubuğunu Düzenle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/liteeditor/liteeditorplugin.cpp" line="77"/>
+        <source>Edit Navigation Bar</source>
+        <translation>Gezinme Çubuğunu Düzenle</translation>
     </message>
 </context>
 <context>
@@ -3332,35 +4437,30 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/liteenv/liteenvoption.ui" line="20"/>
         <source>Environment definition files:</source>
-        <translation>Çalışma ortamı tanımlama dosyaları:</translation>
+        <translation>Ortam değişkeni tanımlama dosyası:</translation>
     </message>
     <message>
         <location filename="src/plugins/liteenv/liteenvoption.ui" line="33"/>
         <source>Environment changes will take effect after switching environments.</source>
-        <translation>Çalışma ortamı değişiklikleri çalışma ortamı değiştikten sonra geçerli olur.</translation>
+        <translation>Ortam değişkenleri değişikliği, ortam değiştirildikten sonra etkili olacaktır.</translation>
     </message>
 </context>
 <context>
     <name>LiteFindPlugin</name>
     <message>
-        <location filename="src/plugins/litefind/litefindplugin.cpp" line="60"/>
-        <source>F&amp;ind</source>
-        <translation>Bul</translation>
-    </message>
-    <message>
         <location filename="src/plugins/litefind/litefindplugin.cpp" line="72"/>
         <source>Find</source>
-        <translation>Bul</translation>
+        <translation>Ara</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/litefindplugin.cpp" line="75"/>
         <source>Find Next</source>
-        <translation>Sonrakini Bul</translation>
+        <translation>Sonrakini Ara</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/litefindplugin.cpp" line="78"/>
         <source>Find Previous</source>
-        <translation>Öncekini Bul</translation>
+        <translation>Öncekini Ara</translation>
     </message>
     <message>
         <location filename="src/plugins/litefind/litefindplugin.cpp" line="81"/>
@@ -3368,69 +4468,69 @@ Success: %2.</oldsource>
         <translation>Değiştir</translation>
     </message>
     <message>
-        <location filename="src/plugins/litefind/litefindplugin.cpp" line="84"/>
+        <location filename="src/plugins/litefind/litefindplugin.cpp" line="87"/>
         <source>File Search</source>
-        <translation>Dosyalarda Ara</translation>
+        <translation>Dosya Ara</translation>
     </message>
 </context>
 <context>
     <name>LiteTabWidget</name>
     <message>
-        <location filename="src/liteapp/litetabwidget.cpp" line="66"/>
+        <location filename="src/utils/tabwidget/litetabwidget.cpp" line="62"/>
         <source>Open a new tab</source>
-        <translation>Yeni bir sekme aç</translation>
+        <translation>Yeni tab aç</translation>
     </message>
     <message>
-        <location filename="src/liteapp/litetabwidget.cpp" line="71"/>
+        <location filename="src/utils/tabwidget/litetabwidget.cpp" line="65"/>
         <source>List All Tabs</source>
-        <translation>Tüm Sekmeleri Listele</translation>
+        <translation>Bütün Tabları Listele</translation>
     </message>
     <message>
-        <location filename="src/liteapp/litetabwidget.cpp" line="77"/>
+        <location filename="src/utils/tabwidget/litetabwidget.cpp" line="71"/>
         <source>Close Tab</source>
-        <translation>Sekmeyi Kapat</translation>
+        <translation>Tabı Kapat</translation>
     </message>
 </context>
 <context>
     <name>MarkdownBatchBrowser</name>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="142"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="143"/>
         <source>Markdown Exporter</source>
         <oldsource>Markdown Batch</oldsource>
-        <translation>Markdown Dışa Aktarıcı</translation>
+        <translation>Markdown Aktarıcı</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="161"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="163"/>
         <source>All Files (*)</source>
         <translation>Tüm Dosyalar (*)</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="230"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="232"/>
         <source>Select the folder containing your markdown files:</source>
         <oldsource>Select Markdown Folder</oldsource>
-        <translation>Markdown dosyalarınızı içeren dizini seçin:</translation>
+        <translation>Markdown dosyalarınızı içeren klasörü seçin:</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="241"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="243"/>
         <source>Select Markdown Files</source>
-        <translation>Markdown Dosyalarını Seç</translation>
+        <translation>Markdown dosyalarınız seçin</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="289"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="291"/>
         <source>Select the folder to contain separated markdown exports:</source>
-        <translation>Markdown dışa aktarımları için dizin seçin:</translation>
+        <translation>Markdown aktarımlarını içeren klasörü seçin:</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="302"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="304"/>
         <source>Export Merged HTML</source>
         <oldsource>Export Html</oldsource>
-        <translation>Tek HTML Olarak Dışa Aktar</translation>
+        <translation>Birleştirilmiş HTML Dışa Aktar</translation>
     </message>
     <message>
-        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="377"/>
+        <location filename="src/plugins/markdown/markdownbatchbrowser.cpp" line="379"/>
         <source>Export Merged PDF</source>
         <oldsource>Export PDF</oldsource>
-        <translation>Tek PDF Olarak Dışa Aktar</translation>
+        <translation>Birleştirilmiş PDF Dışa Aktar</translation>
     </message>
 </context>
 <context>
@@ -3444,19 +4544,19 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="20"/>
         <source>Markdown Source Files</source>
         <oldsource>Markdown Files</oldsource>
-        <translation>Markdown Kaynak Dosyaları</translation>
+        <translation>Kaynak Dosyayı İşaretleyin</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="38"/>
         <source>Import Folder...</source>
         <oldsource>Import Folder</oldsource>
-        <translation>İçe Aktarma Dizini...</translation>
+        <translation>Klasörü İçe Aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="45"/>
         <source>Add Files...</source>
         <oldsource>Add Files</oldsource>
-        <translation>Dosyalar Ekle...</translation>
+        <translation>Dosyaları Ekleyin...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="52"/>
@@ -3471,12 +4571,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="66"/>
         <source>Remove</source>
-        <translation>Kaldır</translation>
+        <translation>Sil</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="73"/>
         <source>Remove All</source>
-        <translation>Tümünü Kaldır</translation>
+        <translation>Tümünü Sil</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="98"/>
@@ -3486,13 +4586,13 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="106"/>
         <source>Export Folder:</source>
-        <translation>Dışa Aktarma Dizini:</translation>
+        <translation>Klasörü Dışa Aktar:</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="116"/>
         <source>Browse...</source>
         <oldsource>Browser</oldsource>
-        <translation>Gözat...</translation>
+        <translation>Araştır...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="127"/>
@@ -3503,13 +4603,13 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="137"/>
         <source>Insert horizontal line between merged files</source>
         <oldsource>Merge files insert split &lt;hr&gt;</oldsource>
-        <translation>Birleşen dosyaların arasına çizgi ekle</translation>
+        <translation>Birleştirilmiş dosyaların drasında çizgi ekle</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="144"/>
         <source>Insert page break between merged files</source>
         <oldsource>Merge files insert page break</oldsource>
-        <translation>Birleşen dosyaların arasına sayfa sonu işareti ekle</translation>
+        <translation>Birleştirilmiş dosyaların arasında ayıraç ekle</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="169"/>
@@ -3521,42 +4621,42 @@ Success: %2.</oldsource>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="175"/>
         <source>Export Separated HTML</source>
         <oldsource>Separate Html</oldsource>
-        <translation>Ayrı HTML Dışa Aktar</translation>
+        <translation>HTML Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="182"/>
         <source>Export Separated PDF</source>
         <oldsource>Separate PDF</oldsource>
-        <translation>Ayrı PDF Dışa Aktar</translation>
+        <translation>PDF Dışa Aktar</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="189"/>
         <source>Export Merged HTML...</source>
         <oldsource>Merge Html</oldsource>
-        <translation>Birleştirilmiş HTML Olarak Dışa Aktar...</translation>
+        <translation>HTML birleştirlenleri aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="196"/>
         <source>Export Merged PDF...</source>
         <oldsource>Merge PDF</oldsource>
-        <translation>Birleştirilmiş PDF Olarak Dışa Aktar...</translation>
+        <translation>PDF birleştirilenleri aktar...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="203"/>
         <source>Print Preview Merged...</source>
         <oldsource>Merge Print Preview</oldsource>
-        <translation>Birleştirilmiş Baskı Önizleme...</translation>
+        <translation>Önizleme (birleştirilmiş.)...</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="210"/>
         <source>Print Merged</source>
         <oldsource>Merge Print</oldsource>
-        <translation>Birleştirerek Yazdır</translation>
+        <translation>Yazdır (birleştirlilmiş.)</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownbatchwidget.ui" line="233"/>
         <source>Log</source>
-        <translation>Günlük</translation>
+        <translation>Log</translation>
     </message>
 </context>
 <context>
@@ -3610,7 +4710,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="107"/>
         <source>Inline Code</source>
-        <translation>Satır İçi Kod</translation>
+        <translation>Çizili</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="110"/>
@@ -3625,7 +4725,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="116"/>
         <source>Unordered List</source>
-        <translation>Sırasız Liste</translation>
+        <translation>Sırasız liste</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="119"/>
@@ -3635,18 +4735,62 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="122"/>
         <source>Blockquote</source>
-        <translation>Alıntı</translation>
+        <translation>Blockquote</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="125"/>
         <source>Horizontal Rule</source>
-        <translation>Yatay Çizgi</translation>
+        <translation>Yatay Ayıraç</translation>
     </message>
     <message>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="131"/>
         <location filename="src/plugins/markdown/markdownedit.cpp" line="154"/>
         <source>Heading</source>
-        <translation>Başlangıç</translation>
+        <translation>Başlık</translation>
+    </message>
+</context>
+<context>
+    <name>MultiFolderView</name>
+    <message>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="289"/>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="296"/>
+        <source>Delete Folder</source>
+        <translation>Klasör Sil</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="290"/>
+        <source>Are you sure that you want to permanently delete this folder and all of its contents?</source>
+        <translation>Bu klasörü ve tüm içeriğini kalıcı olarak silmek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="297"/>
+        <source>Failed to delete the folder!</source>
+        <translation>Klasör Silinemedi!</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="310"/>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="317"/>
+        <source>Delete File</source>
+        <translation>Dosya Sil</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="311"/>
+        <source>Are you sure that you want to permanently delete this file?</source>
+        <translation>Bu dosyayı kalıcı olarak silmek istediğinizden emin misiniz?</translation>
+    </message>
+    <message>
+        <location filename="src/utils/folderview/multifolderview.cpp" line="318"/>
+        <source>Failed to delete the file!</source>
+        <translation>Dosya Silinemedi!</translation>
+    </message>
+</context>
+<context>
+    <name>NavigateBar</name>
+    <message>
+        <location filename="src/utils/navigate/navigate.cpp" line="146"/>
+        <location filename="src/utils/navigate/navigate.cpp" line="169"/>
+        <source>Browser Files in %1</source>
+        <translation>%1&apos;deki Dosyalar</translation>
     </message>
 </context>
 <context>
@@ -3659,12 +4803,12 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="124"/>
         <source>Browse...</source>
-        <translation>Gözat...</translation>
+        <translation>Araştır...</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="24"/>
         <source>GOPATH:</source>
-        <translation type="unfinished"></translation>
+        <translation>GOPATH:</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="38"/>
@@ -3675,7 +4819,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="54"/>
         <source>Type</source>
-        <translation>Tip</translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.ui" line="73"/>
@@ -3701,7 +4845,7 @@ Success: %2.</oldsource>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="126"/>
         <source>Could not create the target directory: %1</source>
-        <translation>Hedef dizin yaratılamıyor: %1</translation>
+        <translation>Hedef dizin oluşturulamadı:%1</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="131"/>
@@ -3712,41 +4856,49 @@ Success: %2.</oldsource>
         <location filename="src/liteapp/newfiledialog.cpp" line="131"/>
         <source>Location %1 is not empty.
 Use the target directory anyway?</source>
-        <translation>%1 dizini boş değil.
-Yine de hedef dizin olarak kullanılsın mı?</translation>
+        <translation>%1 konumu boş değil.
+Yine de hedef dizini kullanılsın mı?</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="168"/>
         <source>Overwrite File</source>
-        <translation>Dosyanın Üzerine Yaz</translation>
+        <translation>Dosyanın üzerine yaz</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="168"/>
         <source>%1 already exists.
 Do you want to replace it?</source>
-        <translation type="unfinished">%1 zaten mevcut.
-Değiştirilmesini istiyor musunuz?</translation>
+        <translation>%1 zaten var.
+Değiştirmek istiyor musun?</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="184"/>
         <source>No files could be created.</source>
-        <translation>Hiç dosya yaratılmadı.</translation>
+        <translation>Dosyalar oluşturulamadı.</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="279"/>
         <source>File template details:</source>
-        <translation type="unfinished">Taslak dosya detayları:</translation>
+        <translation>Dosya taslak ayrıntıları:</translation>
     </message>
     <message>
         <location filename="src/liteapp/newfiledialog.cpp" line="281"/>
         <source>Project template details:</source>
         <oldsource>New project wizard:</oldsource>
-        <translation>Taslak proje detayları:</translation>
+        <translation>Proje taslak ayrıntıları:</translation>
     </message>
     <message>
-        <location filename="src/liteapp/newfiledialog.cpp" line="359"/>
+        <location filename="src/liteapp/newfiledialog.cpp" line="361"/>
         <source>Choose a directory for the new content:</source>
-        <translation>Yeni içerik için bir dizin seçin:</translation>
+        <translation>Yeni içerik için klasör seçin:</translation>
+    </message>
+</context>
+<context>
+    <name>OpenEditorsWidget</name>
+    <message>
+        <location filename="src/liteapp/openeditorswidget.cpp" line="43"/>
+        <source>Open Documents</source>
+        <translation>Dökümanları Aç</translation>
     </message>
 </context>
 <context>
@@ -3766,15 +4918,40 @@ Değiştirilmesini istiyor musunuz?</translation>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="src/liteapp/optionswidget.ui" line="47"/>
+        <location filename="src/liteapp/optionswidget.ui" line="56"/>
         <source>Info</source>
         <translation>Bilgi</translation>
     </message>
     <message>
-        <location filename="src/liteapp/optionswidget.ui" line="72"/>
-        <source>[*] item requeset restart LiteIDE</source>
-        <oldsource>[*] item requeset restart liteide</oldsource>
-        <translation>[*] LiteIDE yeniden başlatılmalıdır</translation>
+        <location filename="src/liteapp/optionswidget.ui" line="106"/>
+        <source>[*] item request restart of LiteIDE</source>
+        <oldsource>[*] item requeset restart LiteIDE</oldsource>
+        <translation>[*] LiteIDE&apos;nin yeniden başlatılması gerekir</translation>
+    </message>
+</context>
+<context>
+    <name>OutputDockWidget</name>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="444"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="472"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="473"/>
+        <source>Move To</source>
+        <translation>Buraya Taşı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="446"/>
+        <source>LeftSideBar</source>
+        <translation>Sol Araç Çubuğı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="447"/>
+        <source>RightSideBar</source>
+        <translation>Sağ Araç Çubuğı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="480"/>
+        <source>BottomDockWidget</source>
+        <translation>Alt İskelet Widget&apos;ı</translation>
     </message>
 </context>
 <context>
@@ -3787,12 +4964,12 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="20"/>
         <source>Font</source>
-        <translation>Yazıtipi</translation>
+        <translation>Font</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="26"/>
         <source>Family:</source>
-        <translation>Aile:</translation>
+        <translation>Küme:</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="43"/>
@@ -3807,12 +4984,12 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="67"/>
         <source>%</source>
-        <translation type="unfinished">%</translation>
+        <translation>%</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="86"/>
         <source>Antialias</source>
-        <translation>Yumuşak kenarlar</translation>
+        <translation>Antialias</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="109"/>
@@ -3822,70 +4999,64 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="115"/>
         <source>Use editor color scheme</source>
-        <translation>Editör renk şemasını kullan</translation>
+        <translation>Düzenleyici renk şemasını kullan</translation>
     </message>
     <message>
         <location filename="src/liteapp/outputoption.ui" line="124"/>
         <source>Sets the maximum number of lines</source>
-        <translation>Maksimum satır sayısını belirler</translation>
+        <translation>Maksimum satır sayısı</translation>
     </message>
 </context>
 <context>
     <name>PackageBrowser</name>
     <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="85"/>
-        <source>Manage GOPATH...</source>
-        <oldsource>Setup GOPATH</oldsource>
-        <translation>GOPATH kurulumu...</translation>
+        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="87"/>
+        <source>Manage GOPATH/Modules ...</source>
+        <oldsource>Manage GOPATH...</oldsource>
+        <translation>GOPATH modülleri düzenle...</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="84"/>
+        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="86"/>
         <source>Reload All</source>
-        <translation>Tümünü Yeniden Yükle</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="91"/>
-        <source>Use godoc View</source>
-        <translation>Godoc Görünümünü Kullan</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="92"/>
-        <source>Load Package in New Window</source>
-        <translation>Paketi Yeni Pencerede Aç</translation>
+        <translation>Hepsini Yenile</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="93"/>
-        <source>Add Package to Folders</source>
-        <translation>Paketi Dizinlere Ekle</translation>
+        <source>Use godoc View</source>
+        <translation>Godoc görüntüleyici kullan</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="94"/>
-        <source>Open Source File</source>
-        <translation>Kaynak Dosyayı Aç</translation>
+        <source>Load Package in New Window</source>
+        <translation>Paketi yeni pencerede yükle</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="95"/>
+        <source>Add Package to Folders</source>
+        <translation>Paketi klasöre ekle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="96"/>
+        <source>Open Source File</source>
+        <translation>Kaynak Dosyası Aç</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="97"/>
         <source>Copy Name to Clipboard</source>
         <oldsource>Copy Name To Clipboard</oldsource>
-        <translation>İsmi Kopyala</translation>
+        <translation>Adı Panoya Kopyala</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="117"/>
-        <source>Package Browser</source>
-        <oldsource>Packge Browser</oldsource>
-        <translation>Paket Gezgini</translation>
+        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="119"/>
+        <source>Go Package Browser</source>
+        <oldsource>Package Browser</oldsource>
+        <translation>Go Paket Gezgini</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="193"/>
-        <source>No Go installation was found.</source>
-        <oldsource>Not find go in PATH...</oldsource>
-        <translation>Go kurulumu bulunamadı.</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="198"/>
+        <location filename="src/plugins/golangpackage/packagebrowser.cpp" line="208"/>
         <source>Loading Go package list...</source>
         <oldsource>Loading go package ...</oldsource>
-        <translation>Go paket listesi yükleniyor...</translation>
+        <translation>Go Paket listesini yükle...</translation>
     </message>
 </context>
 <context>
@@ -3893,34 +5064,39 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="76"/>
         <source>Reload Package</source>
-        <translation>Paketi Yeniden Yükle</translation>
+        <translation>Paketleri Yeniden Yükle</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="77"/>
         <source>Open Explorer Here</source>
-        <translation>İçeren Dizini Göster</translation>
+        <translation>Explorer&apos;i Burada Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/golangpackage/packageproject.cpp" line="78"/>
-        <location filename="src/plugins/golangpackage/packageproject.cpp" line="300"/>
+        <location filename="src/plugins/golangpackage/packageproject.cpp" line="299"/>
         <source>Add Source File</source>
-        <translation>Kaynak Dosya Ekle</translation>
+        <translation>Kaynak Dosyası Ekle</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangpackage/packageproject.cpp" line="311"/>
-        <location filename="src/plugins/golangpackage/packageproject.cpp" line="316"/>
+        <location filename="src/plugins/golangpackage/packageproject.cpp" line="299"/>
+        <source>File Name:</source>
+        <translation>Dosya Adı:</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/golangpackage/packageproject.cpp" line="310"/>
+        <location filename="src/plugins/golangpackage/packageproject.cpp" line="315"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangpackage/packageproject.cpp" line="311"/>
+        <location filename="src/plugins/golangpackage/packageproject.cpp" line="310"/>
         <source>File %1 already exists.</source>
-        <translation>%1 dosyası zaten mevcut.</translation>
+        <translation>%1 dosyası zaten var.</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangpackage/packageproject.cpp" line="316"/>
+        <location filename="src/plugins/golangpackage/packageproject.cpp" line="315"/>
         <source>Could not open %1 for writing.</source>
-        <translation>%1 dosyası yazmak için açılamıyor.</translation>
+        <translation>%1 yazma için açılamadı.</translation>
     </message>
 </context>
 <context>
@@ -3939,7 +5115,7 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="51"/>
         <source>Name</source>
-        <translation>İsim</translation>
+        <translation>Adı</translation>
     </message>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="54"/>
@@ -3954,13 +5130,13 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="53"/>
         <source>Details</source>
-        <translation>Detaylar</translation>
+        <translation>Ayrıntılar</translation>
     </message>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="55"/>
         <source>Version</source>
         <oldsource>Last Ver</oldsource>
-        <translation>Sürüm</translation>
+        <translation>Versiyon</translation>
     </message>
     <message>
         <location filename="src/liteapp/pluginsdialog.cpp" line="56"/>
@@ -3972,47 +5148,47 @@ Değiştirilmesini istiyor musunuz?</translation>
 <context>
     <name>ProcessEx</name>
     <message>
-        <location filename="src/utils/processex/processex.cpp" line="46"/>
-        <source>process exited with code %1</source>
-        <translation>Prosesin çalışması %1 koduyla sonlandı</translation>
-    </message>
-    <message>
-        <location filename="src/utils/processex/processex.cpp" line="49"/>
-        <source>process crashed or was terminated</source>
-        <translation>proses çakıldı veya sonlandırıldı</translation>
-    </message>
-    <message>
         <location filename="src/utils/processex/processex.cpp" line="52"/>
+        <source>process exited with code %1</source>
+        <translation>İşlem %1 koduya kapandı</translation>
+    </message>
+    <message>
+        <location filename="src/utils/processex/processex.cpp" line="55"/>
+        <source>process crashed or was terminated</source>
+        <translation>işlem çöktü veya sonlandırıldı</translation>
+    </message>
+    <message>
+        <location filename="src/utils/processex/processex.cpp" line="58"/>
         <source>process exited with an unknown status</source>
-        <translation>proses bilinmeyen bir durum koduyla sonlandı</translation>
-    </message>
-    <message>
-        <location filename="src/utils/processex/processex.cpp" line="62"/>
-        <source>process failed to start</source>
-        <translation>proses başlatma başarısız</translation>
-    </message>
-    <message>
-        <location filename="src/utils/processex/processex.cpp" line="65"/>
-        <source>process crashed or was terminated while running</source>
-        <translation>proses çalışırken çakıldı veya sonlandırıldı</translation>
+        <translation>bilinmeyen bir durumla işlemden çıkıldı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="68"/>
-        <source>timed out waiting for process</source>
-        <translation>proses beklerken zamanaşımına uğradı</translation>
+        <source>process failed to start</source>
+        <translation>işlem başlatılamadı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="71"/>
-        <source>couldn&apos;t read from the process</source>
-        <translation>prosesin çıktısı okunamıyor</translation>
+        <source>process crashed or was terminated while running</source>
+        <translation>işlem çalışırken çöktü veya sonlandırıldı</translation>
     </message>
     <message>
         <location filename="src/utils/processex/processex.cpp" line="74"/>
-        <source>couldn&apos;t write to the process</source>
-        <translation>prosese yazılamıyor</translation>
+        <source>timed out waiting for process</source>
+        <translation>işlem beklerken zaman aşımına uğradı</translation>
     </message>
     <message>
-        <location filename="src/utils/processex/processex.cpp" line="78"/>
+        <location filename="src/utils/processex/processex.cpp" line="77"/>
+        <source>couldn&apos;t read from the process</source>
+        <translation>süreç okunamadı</translation>
+    </message>
+    <message>
+        <location filename="src/utils/processex/processex.cpp" line="80"/>
+        <source>couldn&apos;t write to the process</source>
+        <translation>sürece yazılamadı</translation>
+    </message>
+    <message>
+        <location filename="src/utils/processex/processex.cpp" line="84"/>
         <source>an unknown error occurred</source>
         <translation>bilinmeyen bir hata oluştu</translation>
     </message>
@@ -4022,12 +5198,12 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/liteapp/projectmanager.cpp" line="95"/>
         <source>Project &lt;%1&gt;</source>
-        <translation>Proje &lt;%1&gt;</translation>
+        <translation>Proje  &lt;%1&gt;</translation>
     </message>
     <message>
         <location filename="src/liteapp/projectmanager.cpp" line="119"/>
         <source>Import Directory &lt;%1&gt;</source>
-        <translation>İçe Aktarım Dizini &lt;%1&gt;</translation>
+        <translation>&lt;%1&gt; Klasörü İçe Aktar</translation>
     </message>
 </context>
 <context>
@@ -4035,27 +5211,27 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/utils/folderview/filesystemmodelex.cpp" line="46"/>
         <source>%1 TB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 TB</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/filesystemmodelex.cpp" line="48"/>
         <source>%1 GB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 GB</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/filesystemmodelex.cpp" line="50"/>
         <source>%1 MB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 MB</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/filesystemmodelex.cpp" line="52"/>
         <source>%1 KB</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 KB</translation>
     </message>
     <message>
         <location filename="src/utils/folderview/filesystemmodelex.cpp" line="53"/>
         <source>%1 bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 byte</translation>
     </message>
 </context>
 <context>
@@ -4063,18 +5239,260 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/3rdparty/qjson/src/parserrunnable.cpp" line="64"/>
         <source>An error occurred while parsing json: %1</source>
-        <translation>JSON okunurken bir hata meydana geldi: %1</translation>
+        <translation>%1 Json ayrıştırılırken bir hata oluştu</translation>
+    </message>
+</context>
+<context>
+    <name>QJsonParseError</name>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="59"/>
+        <source>no error occurred</source>
+        <translation>hata oluşmadı</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="60"/>
+        <source>unterminated object</source>
+        <translation>sonlandırılmamış nesne</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="61"/>
+        <source>missing name separator</source>
+        <translation>isim ayırıcısı eksik</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="62"/>
+        <source>unterminated array</source>
+        <translation>sonlandırılmamış dizi</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="63"/>
+        <source>missing value separator</source>
+        <translation>değer ayırıcısı eksik</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="64"/>
+        <source>illegal value</source>
+        <translation>geçersiz değer</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="65"/>
+        <source>invalid termination by number</source>
+        <translation>geçersiz sonlandırma numarası</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="66"/>
+        <source>illegal number</source>
+        <translation>geçersiz numara</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="67"/>
+        <source>invalid escape sequence</source>
+        <translation>geçersiz kaçış dizisi</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="68"/>
+        <source>invalid UTF8 string</source>
+        <translation>geçersiz UTF-8 karakteri</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="69"/>
+        <source>unterminated string</source>
+        <translation>sonlandırılmamış dize</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="70"/>
+        <source>object is missing after a comma</source>
+        <translation>virgülden sonra nesne eksik</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="71"/>
+        <source>too deeply nested document</source>
+        <translation>çok derin iç içe geçmiş belge</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="72"/>
+        <source>too large document</source>
+        <translation>çok büyük belge</translation>
+    </message>
+    <message>
+        <location filename="src/3rdparty/qjsonrpc/src/json/qjsonparser.cpp" line="73"/>
+        <source>garbage at the end of the document</source>
+        <translation>belgenin sonunda çöp</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenAction</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenaction.cpp" line="59"/>
+        <source>Show and Run Commands</source>
+        <translation>Komutları Göster ve Çalıştır</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenEditor</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopeneditor.cpp" line="56"/>
+        <source>Show All Opened Editors</source>
+        <oldsource>Show All Editors</oldsource>
+        <translation>Tüm Açılmış Düzenleyicileri Göster</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenFileSystem</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenfilesystem.cpp" line="156"/>
+        <source>File System</source>
+        <translation>Dosya Sistemi</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenFiles</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenfiles.cpp" line="72"/>
+        <source>Go to File</source>
+        <translation>Dosyaya Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenfiles.cpp" line="77"/>
+        <source>Type &apos;?&apos; to get help on the actions you can take from here</source>
+        <translation>Burada yapabileceklerinizle ilgili yardım almak için &quot;?&quot; yazın</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenFolder</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenfolder.cpp" line="71"/>
+        <source>Browser Folder</source>
+        <translation>Tarayıcı Klasörü</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenHelp</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenhelp.cpp" line="49"/>
+        <source>Show All Quick Open Actions</source>
+        <oldsource>Show Quick Open Help</oldsource>
+        <translation>Tüm Hızlı Açılış İşlemlerini Göster</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenLines</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenlines.cpp" line="51"/>
+        <source>Go to Line</source>
+        <translation>Satır Git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenlines.cpp" line="79"/>
+        <location filename="src/plugins/quickopen/quickopenlines.cpp" line="84"/>
+        <source>Open a text file first to go to a line</source>
+        <translation>Bir satıra gitmek için önce bir metin dosyası açın</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenlines.cpp" line="97"/>
+        <source>Type a line number between %1 and %2 to navigate to</source>
+        <translation>Gitmek için%1 ile%2 arasında bir satır numarası yazın</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenlines.cpp" line="100"/>
+        <source>Go to Line %1</source>
+        <oldsource>Go to line %1</oldsource>
+        <translation>%1 No&apos;lu Satıra Git</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenManager</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmanager.cpp" line="82"/>
+        <source>Quick Open File</source>
+        <translation>Hızlı Dosya Açma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmanager.cpp" line="83"/>
+        <source>Quick Open Editor</source>
+        <translation>Hızlı Editör Açma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmanager.cpp" line="84"/>
+        <source>Quick Open Symbol</source>
+        <translation>Hızlı Sembol Açma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmanager.cpp" line="85"/>
+        <source>Quick Open Command</source>
+        <translation>Hızlı Komut Açma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmanager.cpp" line="86"/>
+        <source>Show All Quick Open Actions</source>
+        <translation>Tüm Hızlı Açmaları Göster</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenMimeType</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmimetype.cpp" line="41"/>
+        <source>Go to Symbol in File</source>
+        <oldsource>Open Symbol by Name</oldsource>
+        <translation>Dosyadaki sembole git</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenmimetype.cpp" line="42"/>
+        <source>not found symbol</source>
+        <translation>sembol bulunamadı</translation>
+    </message>
+</context>
+<context>
+    <name>QuickOpenOption</name>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenoption.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenoption.ui" line="20"/>
+        <source>QuickOpenFiles</source>
+        <translation>Hızlı Dosya Açma</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenoption.ui" line="26"/>
+        <location filename="src/plugins/quickopen/quickopenoption.ui" line="79"/>
+        <source>Match case sensitive</source>
+        <translation>Büyük / küçük harfe duyarlı</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenoption.ui" line="35"/>
+        <source>Max files count:</source>
+        <translation>En Fazla Dosya Sayısı:</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/quickopen/quickopenoption.ui" line="73"/>
+        <source>QuickOpenEditor</source>
+        <translation>Hızlı Açma Düzeni</translation>
+    </message>
+</context>
+<context>
+    <name>RecentManager</name>
+    <message>
+        <location filename="src/liteapp/recentmanager.cpp" line="54"/>
+        <source>Clear All History</source>
+        <translation>Tüm Geçmişi Temizle</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/recentmanager.cpp" line="169"/>
+        <source>Clear Menu</source>
+        <translation>Menüyü Temizle</translation>
     </message>
 </context>
 <context>
     <name>SearchEdit</name>
     <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="81"/>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="83"/>
         <source>Search</source>
         <translation>Ara</translation>
     </message>
     <message>
-        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="82"/>
+        <location filename="src/plugins/golangdoc/finddocwidget.cpp" line="84"/>
         <source>Stop Search</source>
         <translation>Aramayı Durdur</translation>
     </message>
@@ -4084,7 +5502,7 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="14"/>
         <source>Debug External Application</source>
-        <translation>Harici Uygulamada Hata Ayıkla</translation>
+        <translation>Harici Uygulamada Hata Ayıklama</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="22"/>
@@ -4096,156 +5514,195 @@ Değiştirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="56"/>
         <source>Browse...</source>
         <oldsource>Browser</oldsource>
-        <translation>Gözat...</translation>
+        <translation>Araştır...</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="36"/>
         <source>Arguments:</source>
-        <translation>Parametreler:</translation>
+        <translation>Argümanlar:</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.ui" line="46"/>
         <source>Working directory:</source>
-        <translation>Çalşma dizini:</translation>
+        <translation>Çalışma Klasörü:</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.cpp" line="82"/>
         <source>Select Executable</source>
-        <translation>Çalıştırlabilir Dosya Seçin</translation>
+        <translation>Uygulama Seçin</translation>
     </message>
     <message>
         <location filename="src/plugins/litedebug/selectexternaldialog.cpp" line="92"/>
         <source>Select the working directory:</source>
         <oldsource>Select Working Directory</oldsource>
-        <translation>Çalışma dizinini seçin:</translation>
+        <translation>Çalışma klasörü seçimi:</translation>
     </message>
 </context>
 <context>
-    <name>SetupGopathDialog</name>
+    <name>SessionRecent</name>
     <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="14"/>
-        <source>Manage GOPATH</source>
-        <translation>GOPATH&apos;ı Yönet</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="20"/>
-        <source>System GOPATH</source>
-        <translation>Sistemde Kayıtlı GOPATH</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="35"/>
-        <source>Reload</source>
-        <translation>Yeniden Yükle</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="60"/>
-        <source>Custom Directories (one per line)</source>
-        <translation>Özel Dizinler (satır başına bir tane)</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="71"/>
-        <source>Add Directory...</source>
-        <translation>Dizin Ekle...</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.ui" line="78"/>
-        <source>Clear</source>
-        <translation>Temizle</translation>
-    </message>
-    <message>
-        <location filename="src/plugins/golangpackage/setupgopathdialog.cpp" line="74"/>
-        <source>Choose directory to add to GOPATH:</source>
-        <oldsource>Load GOPATH Directory</oldsource>
-        <translation>GOPATH'e eklemek için dizin seçin:</translation>
+        <location filename="src/liteapp/recentmanager.h" line="197"/>
+        <source>Sessions</source>
+        <translation>Oturumlar</translation>
     </message>
 </context>
 <context>
     <name>SideDockWidget</name>
     <message>
-        <location filename="src/liteapp/sidewindowstyle.cpp" line="58"/>
-        <source>SideBar</source>
-        <translation>Sidebar</translation>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="50"/>
+        <source>Move To</source>
+        <translation>.. ya taşı</translation>
     </message>
     <message>
-        <location filename="src/liteapp/sidewindowstyle.cpp" line="59"/>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="54"/>
+        <source>RightSideBar</source>
+        <translation>Sağ Taraf Paneli</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="56"/>
+        <source>LeftDockWidgt</source>
+        <translation>Sol Panel Aracı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="58"/>
+        <source>LeftSideBar</source>
+        <translation>Sol Taraf Panel</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="60"/>
+        <source>RightDockWidget</source>
+        <translation>Sağ Panel Aracı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="63"/>
+        <source>OutputBar</source>
+        <translation>Çıkış Panel</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="75"/>
+        <source>SideBar</source>
+        <translation>Panel</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="76"/>
         <source>Show SideBar</source>
-        <translation>Sidebar&apos;ı Göster</translation>
+        <translation>Paneli Göster</translation>
     </message>
 </context>
 <context>
     <name>SideWindowStyle</name>
     <message>
-        <location filename="src/liteapp/sidewindowstyle.cpp" line="428"/>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="547"/>
         <source>Hide SideBar</source>
-        <translation>Sidebar&apos;ı Gizle</translation>
+        <translation>Yan Çubuğu Gizle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/sidewindowstyle.cpp" line="461"/>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="585"/>
         <source>SideBar Windows</source>
-        <translation>Sidebar Pencereleri</translation>
+        <translation>Yan Çubuk Penceresi</translation>
     </message>
     <message>
-        <location filename="src/liteapp/sidewindowstyle.cpp" line="462"/>
+        <location filename="src/liteapp/sidewindowstyle.cpp" line="586"/>
         <source>Output Windows</source>
-        <translation>Çıktı Pencereleri</translation>
+        <translation>Çıktı Penceresi</translation>
     </message>
 </context>
 <context>
     <name>SplitDockWidget</name>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="199"/>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="267"/>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="268"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="300"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="379"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="380"/>
         <source>Move To</source>
-        <translation>Şuraya Taşı</translation>
+        <translation>..ya taşı</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="201"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="302"/>
         <source>Top</source>
-        <translation>Üste</translation>
+        <translation>Üst</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="205"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="306"/>
         <source>Top (Split)</source>
-        <translation>Üste (Böl)</translation>
+        <translation>Üst (bölünmüş)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="211"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="343"/>
+        <source>TopDockWidget (Split)</source>
+        <translation>Üst Panel Aracı (bölünmüş)</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="343"/>
+        <source>TopDockWidget</source>
+        <translation>Üst Panel Aracı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="312"/>
         <source>Bottom</source>
-        <translation>Alta</translation>
+        <translation>Alt</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="215"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="316"/>
         <source>Bottom (Split)</source>
-        <translation>Alta (Böl)</translation>
+        <translation>Alt (bölünmüş)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="221"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="345"/>
+        <source>BottomDockWidget (Split)</source>
+        <translation>Alt Panel Aracı (bölünmüş)</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="345"/>
+        <source>BottomDockWidget</source>
+        <translation>Alt Panel Aracı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="322"/>
         <source>Left</source>
-        <translation>Sola</translation>
+        <translation>Sol</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="225"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="326"/>
         <source>Left (Split)</source>
-        <translation>Sola (Böl)</translation>
+        <translation>Sol (bölünmüş)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="231"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="347"/>
+        <source>LeftDockWidget (Split)</source>
+        <translation>Sol Panel Aracı (bölünmüş)</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="347"/>
+        <source>LeftDockWidget</source>
+        <translation>Sol Panel Aracı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="332"/>
         <source>Right</source>
-        <translation>Sağa</translation>
+        <translation>Sağ</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="235"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="336"/>
         <source>Right (Split)</source>
-        <translation>Sağa (Böl)</translation>
+        <translation>Sağ (bölünmüş)</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="243"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="349"/>
+        <source>RightDockWidget (Split)</source>
+        <translation>Sağ Panel Aracı (bölünmüş)</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="349"/>
+        <source>RightDockWidget</source>
+        <translation>Sağ Panel Aracı</translation>
+    </message>
+    <message>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="355"/>
         <source>Unsplit</source>
-        <translation>Birleştir</translation>
+        <translation>Bölme</translation>
     </message>
     <message>
-        <location filename="src/liteapp/tooldockwidget.cpp" line="248"/>
+        <location filename="src/liteapp/tooldockwidget.cpp" line="360"/>
         <source>Split</source>
         <translation>Böl</translation>
     </message>
@@ -4253,40 +5710,116 @@ Değiştirilmesini istiyor musunuz?</translation>
 <context>
     <name>SplitWindowStyle</name>
     <message>
-        <location filename="src/liteapp/splitwindowstyle.cpp" line="242"/>
+        <location filename="src/liteapp/splitwindowstyle.cpp" line="244"/>
         <source>Hide Sidebars</source>
-        <translation>Sidebar&apos;ları Gizle</translation>
+        <translation>Kenar Çubuklarını Gizle</translation>
     </message>
     <message>
-        <location filename="src/liteapp/splitwindowstyle.cpp" line="275"/>
+        <location filename="src/liteapp/splitwindowstyle.cpp" line="278"/>
         <source>Tool Windows</source>
         <translation>Araç Pencereleri</translation>
     </message>
 </context>
 <context>
+    <name>Terminal</name>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="132"/>
+        <location filename="src/plugins/terminal/terminal.cpp" line="189"/>
+        <location filename="src/plugins/terminal/terminal.cpp" line="773"/>
+        <source>New</source>
+        <translation>Yeni</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="133"/>
+        <source>Open a new terminal</source>
+        <translation>Yeni Terminla Aç</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="135"/>
+        <source>Close</source>
+        <translation>Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="136"/>
+        <source>Close current terminal</source>
+        <translation>Geçerli Terminali Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="138"/>
+        <source>CloseAll</source>
+        <translation>Tümünü Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="139"/>
+        <source>Close all terminal</source>
+        <translation>Tüm Terminalleri Kapat</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="142"/>
+        <source>LoadEnv</source>
+        <translation>Ortam Değişkenlerini Yükle</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="143"/>
+        <source>Current terminal load environment from LiteIDE</source>
+        <translation>LiteIDE&apos;den mevcut terminale ortam değişkenlerini aktar</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="148"/>
+        <source>Filter</source>
+        <translation>Filter</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="184"/>
+        <source>Dark Mode</source>
+        <translation>Karanlık Mod</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="195"/>
+        <source>Login Mode (shell --login)</source>
+        <translation>Giriş Yöntemi (shell --login)</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="237"/>
+        <location filename="src/plugins/terminal/terminal.cpp" line="741"/>
+        <source>Terminal</source>
+        <translation>Terminal</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="251"/>
+        <source>Open in Integrated Terminal</source>
+        <translation>Gömülü Terminalde Aç</translation>
+    </message>
+    <message>
+        <location filename="src/plugins/terminal/terminal.cpp" line="741"/>
+        <source>Rename Tab Title</source>
+        <translation>Sekme Başlığını Teniden Adlandır</translation>
+    </message>
+</context>
+<context>
     <name>TerminalEdit</name>
     <message>
-        <location filename="src/utils/textoutput/terminaledit.cpp" line="60"/>
+        <location filename="src/utils/textoutput/terminaledit.cpp" line="67"/>
         <source>Cut</source>
         <translation>Kes</translation>
     </message>
     <message>
-        <location filename="src/utils/textoutput/terminaledit.cpp" line="63"/>
+        <location filename="src/utils/textoutput/terminaledit.cpp" line="71"/>
         <source>Copy</source>
         <translation>Kopyala</translation>
     </message>
     <message>
-        <location filename="src/utils/textoutput/terminaledit.cpp" line="66"/>
+        <location filename="src/utils/textoutput/terminaledit.cpp" line="75"/>
         <source>Paste</source>
         <translation>Yapıştır</translation>
     </message>
     <message>
-        <location filename="src/utils/textoutput/terminaledit.cpp" line="69"/>
+        <location filename="src/utils/textoutput/terminaledit.cpp" line="79"/>
         <source>Select All</source>
         <translation>Tümünü Seç</translation>
     </message>
     <message>
-        <location filename="src/utils/textoutput/terminaledit.cpp" line="72"/>
+        <location filename="src/utils/textoutput/terminaledit.cpp" line="83"/>
         <source>Clear All</source>
         <translation>Tümünü Temizle</translation>
     </message>
@@ -4296,7 +5829,7 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/3rdparty/qtc_texteditor/colorscheme.cpp" line="212"/>
         <source>Not a color scheme file.</source>
-        <translation>Geçerli bir renk şema dosyası değil.</translation>
+        <translation>Renk düzeni dosyası değil.</translation>
     </message>
 </context>
 <context>
@@ -4309,37 +5842,37 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/3rdparty/qtc_editutil/filterlineedit.cpp" line="52"/>
         <source>Clear text</source>
-        <translation>Metni temizle</translation>
+        <translation>Yazıyı temizle</translation>
     </message>
 </context>
 <context>
     <name>WebKitBrowser</name>
     <message>
-        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="69"/>
+        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="70"/>
         <source>Navigation</source>
         <translation>Navigasyon</translation>
     </message>
     <message>
-        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="72"/>
+        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="73"/>
         <source>Open Html File</source>
         <oldsource>Open Html</oldsource>
-        <translation>HTML Dosyası Aç</translation>
+        <translation>HTML-Dosyası Aç</translation>
     </message>
     <message>
-        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="119"/>
+        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="120"/>
         <source>WebKitBrowser</source>
-        <translation>WebKit Tabanlı Tarayıcı</translation>
+        <translation>WebKit-Browser</translation>
     </message>
     <message>
-        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="169"/>
+        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="170"/>
         <source>False load %1 !</source>
-        <translation>%1 yüklenemiyor!</translation>
+        <translation>%1 Tüklemede Hata!</translation>
     </message>
     <message>
-        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="256"/>
+        <location filename="src/plugins/webkithtmlwidget/webkitbrowser.cpp" line="257"/>
         <source>Open Html or Markdown File</source>
         <oldsource>Open Html or Markdown Files</oldsource>
-        <translation>HTML veya Markdown Dosyası Aç</translation>
+        <translation>HTMLveya Markdown-Dosyası Aç</translation>
     </message>
 </context>
 <context>
@@ -4348,7 +5881,7 @@ Değiştirilmesini istiyor musunuz?</translation>
         <location filename="src/plugins/webkithtmlwidget/webkithtmlwidgetplugin.cpp" line="74"/>
         <source>Open Html or Markdown File</source>
         <oldsource>Open Html or Markdown Files</oldsource>
-        <translation>HTML veya Markdown Dosyası Aç</translation>
+        <translation>Html veya Markdown Dosyasını Açın</translation>
     </message>
 </context>
 <context>
@@ -4366,7 +5899,7 @@ Değiştirilmesini istiyor musunuz?</translation>
     <message>
         <location filename="src/plugins/welcome/welcomebrowser.cpp" line="67"/>
         <source>Open Folder</source>
-        <translation>Dizin Aç</translation>
+        <translation>Klasör Aç</translation>
     </message>
     <message>
         <location filename="src/plugins/welcome/welcomebrowser.cpp" line="68"/>
@@ -4374,7 +5907,7 @@ Değiştirilmesini istiyor musunuz?</translation>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="src/plugins/welcome/welcomebrowser.cpp" line="216"/>
+        <location filename="src/plugins/welcome/welcomebrowser.cpp" line="207"/>
         <source>Welcome</source>
         <oldsource>Welcome Page</oldsource>
         <translation>Hoşgeldiniz</translation>
@@ -4383,7 +5916,7 @@ Değiştirilmesini istiyor musunuz?</translation>
 <context>
     <name>WelcomePlugin</name>
     <message>
-        <location filename="src/plugins/welcome/welcomeplugin.cpp" line="71"/>
+        <location filename="src/plugins/welcome/welcomeplugin.cpp" line="72"/>
         <source>Welcome</source>
         <oldsource>Home</oldsource>
         <translation>Hoşgeldiniz</translation>


### PR DESCRIPTION
Corrected Turkish Language Translation.
Now it is compatible with new version of LiteIDE.

![Untitled](https://user-images.githubusercontent.com/78525170/107126202-6d7ec980-68bf-11eb-8cf8-1c651e5f9db8.jpg)
