### PR TITLE
Running go playground with a keyboard shortcut

### DIFF
--- a/liteidex/src/plugins/golangplay/goplaybrowser.cpp
+++ b/liteidex/src/plugins/golangplay/goplaybrowser.cpp
@@ -102,6 +102,12 @@ GoplayBrowser::GoplayBrowser(LiteApi::IApplication *app, QObject *parent)
     m_process = new ProcessEx(this);
     m_codec = QTextCodec::codecForName("utf-8");
 
+    LiteApi::IActionContext *actionContext = m_liteApp->actionManager()->getActionContext(m_liteApp,"App");
+    m_runGoPlay = new QAction(QIcon("icon:images/gopher.png"),tr("Run GoPlay"),this);
+    actionContext->regAction(m_runGoPlay,"GoplayRun","Ctrl+Alt+R");
+    connect(m_runGoPlay,SIGNAL(triggered()),this,SLOT(run()));
+    m_widget->addAction(m_runGoPlay);
+
     connect(run,SIGNAL(triggered()),this,SLOT(run()));
     connect(stop,SIGNAL(triggered()),this,SLOT(stop()));
     connect(_new,SIGNAL(triggered()),this,SLOT(newPlay()));

--- a/liteidex/src/plugins/golangplay/goplaybrowser.h
+++ b/liteidex/src/plugins/golangplay/goplaybrowser.h
@@ -62,6 +62,7 @@ protected:
     QString           m_dataPath;
     QString           m_playFile;
     QString           m_editFile;
+    QAction           *m_runGoPlay;
 };
 
 #endif // GOPLAYBROWSER_H


### PR DESCRIPTION
Running go playground with a keyboard shortcut, Ctrl+Alt+R as a default