### PR TITLE
inherit font setting for terminal

### DIFF
--- a/liteidex/src/plugins/terminal/terminal.cpp
+++ b/liteidex/src/plugins/terminal/terminal.cpp
@@ -396,7 +396,7 @@ void Terminal::openDefaultTerminal(const QString &workDir)
     //QString title = QString("%1 %2").arg(m_curName).arg(++m_indexId);
     dir = QDir::toNativeSeparators(workDir);
     //openNewTerminal(cmdName,m_loginMode,title,dir,env);
-    VTermWidget *term = new VTermWidget(m_widget);
+    VTermWidget *term = new VTermWidget(m_liteApp, m_widget);
     QString title = makeTitle(QFileInfo(dir).fileName());
     int index = m_tab->addTab(term,title,dir);
     m_tab->setCurrentIndex(index);
@@ -410,7 +410,7 @@ void Terminal::appLoaded()
     foreach(QString key,m_liteApp->settings()->childKeys()) {
         TabInfoData data = m_liteApp->settings()->value(key).value<TabInfoData>();
         if (!data.cmd.isEmpty() && !data.title.isEmpty()) {
-            VTermWidget *widget = new VTermWidget(m_widget);
+            VTermWidget *widget = new VTermWidget(m_liteApp, m_widget);
             int index = m_tab->addTab(widget,data.title,QDir::toNativeSeparators(data.dir));
             data.open = false;
             m_tab->setTabData(index,QVariant::fromValue(data));
@@ -614,7 +614,7 @@ void Terminal::newTerminal()
     dir = QDir::toNativeSeparators(dir);
     QString title = makeTitle(QFileInfo(dir).fileName());
     //openNewTerminal(cmdName,m_loginMode,title,dir,env);
-    VTermWidget *term = new VTermWidget(m_widget);
+    VTermWidget *term = new VTermWidget(m_liteApp, m_widget);
     int index = m_tab->addTab(term,title,QDir::toNativeSeparators(dir));
 
     m_tab->setCurrentIndex(index);

--- a/liteidex/src/utils/vterm/vtermwidget.cpp
+++ b/liteidex/src/utils/vterm/vtermwidget.cpp
@@ -40,7 +40,7 @@
 #endif
 
 
-VTermWidget::VTermWidget(QWidget *parent) : VTermWidgetBase(24,80,parent)
+VTermWidget::VTermWidget(LiteApi::IApplication *app,QWidget *parent) : VTermWidgetBase(app,24,80,parent),m_liteApp(app)
 {
     this->setContextMenuPolicy(Qt::CustomContextMenu);
     m_process = PtyQt::createPtyProcess(IPtyProcess::AutoPty);

--- a/liteidex/src/utils/vterm/vtermwidget.h
+++ b/liteidex/src/utils/vterm/vtermwidget.h
@@ -24,6 +24,7 @@
 #ifndef VTERMWIDGET_H
 #define VTERMWIDGET_H
 
+#include "liteapi/liteapi.h"
 #include "vtermwidgetbase.h"
 #include "ptyqt/core/ptyqt.h"
 
@@ -34,7 +35,7 @@ class VTermWidget : public VTermWidgetBase
 {
     Q_OBJECT
 public:
-    explicit VTermWidget(QWidget *parent);
+    explicit VTermWidget(LiteApi::IApplication *app,QWidget *parent);
     virtual ~VTermWidget();
     bool isAvailable() const;
     void start(const QString &program, const QStringList &arguments, const QString &workingDirectory, QStringList env);
@@ -57,6 +58,7 @@ protected:
     IPtyProcess *m_process;
     QMenu *m_contextMenu;
     bool m_bStarted;
+    LiteApi::IApplication *m_liteApp;
     QAction *m_copy;
     QAction *m_paste;
     QAction *m_selectAll;

--- a/liteidex/src/utils/vterm/vtermwidgetbase.cpp
+++ b/liteidex/src/utils/vterm/vtermwidgetbase.cpp
@@ -22,6 +22,7 @@
 // Creator: visualfc <visualfc@gmail.com>
 
 #include "vtermwidgetbase.h"
+#include "../liteapp/liteapp_global.h"
 #include <QFontMetrics>
 #include <QPainter>
 #include <QScrollBar>
@@ -103,17 +104,17 @@ static VTermScreenCallbacks vterm_screen_callbacks = {
 };
 
 
-VTermWidgetBase::VTermWidgetBase(int rows, int cols, QWidget *parent)
-    : QAbstractScrollArea(parent)
+VTermWidgetBase::VTermWidgetBase(LiteApi::IApplication *app,int rows, int cols, QWidget *parent)
+    : QAbstractScrollArea(parent),
+    m_liteApp(app)
 {
     this->setAttribute(Qt::WA_InputMethodEnabled,true);
-#ifdef Q_OS_LINUX
-    setFont(QFont("DejaVu Sans Mono",11));
-#elif defined(Q_OS_WIN)
-    setFont(QFont("Courier",11));
-#else
-    setFont(QFont("Menlo",12));
-#endif
+
+    int fontSize = m_liteApp->settings()->value(OUTPUT_FONTSIZE,11).toInt();
+    QString fontFamily = m_liteApp->settings()->value(OUTPUT_FAMILY).toString();
+    QFont font = QFont(fontFamily,fontSize);
+    setFont(font);
+
     m_sbListCapacity = 10000;
     m_rows = rows;
     m_cols = cols;

--- a/liteidex/src/utils/vterm/vtermwidgetbase.h
+++ b/liteidex/src/utils/vterm/vtermwidgetbase.h
@@ -28,6 +28,8 @@ extern "C" {
 #include "libvterm/include/vterm.h"
 }
 
+#include "liteapi/liteapi.h"
+
 #include <QAbstractScrollArea>
 #include <QBasicTimer>
 #include <QDebug>
@@ -52,7 +54,7 @@ class VTermWidgetBase : public QAbstractScrollArea
 {
     Q_OBJECT
 public:
-    VTermWidgetBase(int rows, int cols, QWidget *parent);
+    VTermWidgetBase(LiteApi::IApplication *app,int rows, int cols, QWidget *parent);
     virtual ~VTermWidgetBase();
     void setFont(const QFont &fnt);
     void setTermSize(int rows, int cols);
@@ -120,6 +122,7 @@ signals:
     void output(char *buf, int len);
     void selectionChanged();
 protected:
+    LiteApi::IApplication *m_liteApp;
     int m_rows;
     int m_cols;
     int  m_propMouse;


### PR DESCRIPTION
Hello visualfc,
i wrote a little patch to fix a problem with the terminal plugin font on freebsd (all versions). Without this, the selected font renders unusable on my system. I successfully tested it on freebsd 13.0 and 13.1. Maybe you find it useful. I removed  a few ifdefs there, although i couldn´t check the other platforms. But I think the code should work everywhere. 
best regards 
