### PR TITLE
Search file's current folder button focuses directory combo

### DIFF
--- a/liteidex/src/plugins/litefind/filesearch.cpp
+++ b/liteidex/src/plugins/litefind/filesearch.cpp
@@ -472,7 +472,7 @@ void FileSearch::currentDir()
             m_findPathCombo->setEditText(info.path());
         }
     }
-
+    m_findPathCombo->setFocus();
 }
 
 void FileSearch::browser()


### PR DESCRIPTION
So the user can still edit directory if (s)he wants to, also search by enter when https://github.com/visualfc/liteide/pull/1279 is merged too.