### PR TITLE
Convert std::mem_fun_ref and std::ptr_fun into expressions compatible with C++17

### DIFF
--- a/liteidex/src/3rdparty/qtc_texteditor/generichighlighter/rule.cpp
+++ b/liteidex/src/3rdparty/qtc_texteditor/generichighlighter/rule.cpp
@@ -155,7 +155,7 @@ bool Rule::charPredicateMatchSucceed(const QString &text,
                                      ProgressData *progress,
                                      bool (QChar::* predicate)() const) const
 {
-    return predicateMatchSucceed(text, length, progress, std::mem_fun_ref(predicate));
+    return predicateMatchSucceed(text, length, progress, std::mem_fn(predicate));
 }
 
 bool Rule::charPredicateMatchSucceed(const QString &text,
@@ -163,7 +163,8 @@ bool Rule::charPredicateMatchSucceed(const QString &text,
                                      ProgressData *progress,
                                      bool (*predicate)(const QChar &)) const
 {
-    return predicateMatchSucceed(text, length, progress, std::ptr_fun(predicate));
+    std::function<bool(const QChar&)> predicateFunc = predicate;
+    return predicateMatchSucceed(text, length, progress, predicateFunc);
 }
 
 bool Rule::matchSucceed(const QString &text, const int length, ProgressData *progress)


### PR DESCRIPTION
Currently the build of LiteIdeX on FreeBSD 14 is broken. The reason is that the system compiler Clang was updated to version 16 and with this (apparently) the deprecation of some std-functions became final. I'm not a C++ guru and I've made up the solution with the help of Google - if it makes sense to you, it would be nice to commit this or a better fix for the problem. I have successfully tested the fix on FreeBSD 14, but can't comment on backwards compatibility with older C++ compilers.