### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/liteidex/src/3rdparty/qjsonrpc/src/http-parser/http_parser.c
+++ b/liteidex/src/3rdparty/qjsonrpc/src/http-parser/http_parser.c
@@ -1300,6 +1300,12 @@ size_t http_parser_execute (http_parser *parser,
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
                 parser->header_state = h_transfer_encoding;
+                /* Multiple `Transfer-Encoding` headers should be treated as
+                 * one, but with values separate by a comma.
+                 *
+                 * See: https://tools.ietf.org/html/rfc7230#section-3.2.2
+                 */
+                parser->flags &= ~F_CHUNKED;
               }
               break;
 


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in http_parser_execute() that was cloned from node but did not receive the security patch. The original issue was reported and fixed under https://github.com/nodejs/node/commit/fc70ce08f5818a286fb5899a1bc3aff5965a745e.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-8287
https://github.com/nodejs/node/commit/fc70ce08f5818a286fb5899a1bc3aff5965a745e
