### PR TITLE
Fix: src/3rdparty/libvterm: crash when out of memory while opening a terminal window 

### DIFF
--- a/liteidex/src/3rdparty/libvterm/src/state.c
+++ b/liteidex/src/3rdparty/libvterm/src/state.c
@@ -52,6 +52,8 @@ static VTermState *vterm_state_new(VTerm *vt)
 {
   VTermState *state = vterm_allocator_malloc(vt, sizeof(VTermState));
 
+  if (state == NULL)
+    return NULL;
   state->vt = vt;
 
   state->rows = vt->rows;
@@ -1736,6 +1738,8 @@ VTermState *vterm_obtain_state(VTerm *vt)
     return vt->state;
 
   VTermState *state = vterm_state_new(vt);
+  if (state == NULL)
+    return NULL;
   vt->state = state;
 
   state->combine_chars_size = 16;

--- a/liteidex/src/3rdparty/libvterm/src/vterm.c
+++ b/liteidex/src/3rdparty/libvterm/src/vterm.c
@@ -37,6 +37,8 @@ VTerm *vterm_new_with_allocator(int rows, int cols, VTermAllocatorFunctions *fun
   /* Need to bootstrap using the allocator function directly */
   VTerm *vt = (*funcs->malloc)(sizeof(VTerm), allocdata);
 
+  if (vt == NULL)
+    return NULL;
   vt->allocator = funcs;
   vt->allocdata = allocdata;
 
@@ -51,6 +53,11 @@ VTerm *vterm_new_with_allocator(int rows, int cols, VTermAllocatorFunctions *fun
   vt->parser.strbuffer_len = 64;
   vt->parser.strbuffer_cur = 0;
   vt->parser.strbuffer = vterm_allocator_malloc(vt, vt->parser.strbuffer_len);
+  if (vt->parser.strbuffer == NULL)
+  {
+    vterm_allocator_free(vt, vt);
+    return NULL;
+  }
 
   vt->outfunc = NULL;
   vt->outdata = NULL;
@@ -58,6 +65,12 @@ VTerm *vterm_new_with_allocator(int rows, int cols, VTermAllocatorFunctions *fun
   vt->outbuffer_len = 64;
   vt->outbuffer_cur = 0;
   vt->outbuffer = vterm_allocator_malloc(vt, vt->outbuffer_len);
+  if (vt->outbuffer == NULL)
+  {
+    vterm_allocator_free(vt, vt->parser.strbuffer);
+    vterm_allocator_free(vt, vt);
+    return NULL;
+  }
 
   vt->tmpbuffer_len = 64;
   vt->tmpbuffer = vterm_allocator_malloc(vt, vt->tmpbuffer_len);
@@ -87,7 +100,8 @@ INTERNAL void *vterm_allocator_malloc(VTerm *vt, size_t size)
 
 INTERNAL void vterm_allocator_free(VTerm *vt, void *ptr)
 {
-  (*vt->allocator->free)(ptr, vt->allocdata);
+  if (ptr)
+    (*vt->allocator->free)(ptr, vt->allocdata);
 }
 
 void vterm_get_size(const VTerm *vt, int *rowsp, int *colsp)


### PR DESCRIPTION
Dear Development team, 

I identified vulnerabilities in clone functions sourced from [vim/vim](https://github.com/vim/vim). These issues, originally reported in [CVE-2018-20786](https://nvd.nist.gov/vuln/detail/CVE-2018-20786), were resolved in the Vim repository via this commit https://github.com/vim/vim/commit/cd929f7ba8cc5b6d6dcf35c8b34124e969fed6b8. 

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!
