### PR TITLE
feat: add theme manager for light/dark theme of app and editor

### DIFF
--- a/liteidex/src/liteapp/liteapp.cpp
+++ b/liteidex/src/liteapp/liteapp.cpp
@@ -74,6 +74,10 @@
 
 #define LITEIDE_VERSION "X38.4"
 
+//chen
+extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
+extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
+
 
 QString LiteApp::getRootPath()
 {
@@ -136,6 +140,9 @@ IApplication* LiteApp::NewApplication(const QString &sessionName, IApplication *
 {
     LiteApp *app = new LiteApp;
     app->load(sessionName,baseApp);
+
+    //chen: improve for new app instance
+    auto_editor_theme(LiteApp::s_darkMode, app);
     return app;
 }
 
@@ -153,6 +160,8 @@ QList<IApplication *> LiteApp::appList()
 QMap<QString,QVariant> LiteApp::s_cookie;
 
 QList<IApplication*> LiteApp::s_appList;
+
+bool LiteApp::s_darkMode;
 
 LiteApp::LiteApp()
     : m_rootPath(LiteApp::getRootPath()),

--- a/liteidex/src/liteapp/liteapp.cpp
+++ b/liteidex/src/liteapp/liteapp.cpp
@@ -62,6 +62,9 @@
 #include <QComboBox>
 #include <QProcessEnvironment>
 #include <QDebug>
+
+#include "thememanager.h"
+
 //lite_memory_check_begin
 #if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
      #define _CRTDBG_MAP_ALLOC
@@ -142,7 +145,9 @@ IApplication* LiteApp::NewApplication(const QString &sessionName, IApplication *
     app->load(sessionName,baseApp);
 
     //chen: improve for new app instance
-    auto_editor_theme(LiteApp::s_darkMode, app);
+    // auto_editor_theme(LiteApp::s_darkMode, app);
+    ThemeManager::apply_to_liteApp(app);
+
     return app;
 }
 

--- a/liteidex/src/liteapp/liteapp.cpp
+++ b/liteidex/src/liteapp/liteapp.cpp
@@ -77,10 +77,6 @@
 
 #define LITEIDE_VERSION "X38.4"
 
-//chen
-extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
-extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
-
 
 QString LiteApp::getRootPath()
 {
@@ -145,7 +141,6 @@ IApplication* LiteApp::NewApplication(const QString &sessionName, IApplication *
     app->load(sessionName,baseApp);
 
     //chen: improve for new app instance
-    // auto_editor_theme(LiteApp::s_darkMode, app);
     ThemeManager::apply_to_liteApp(app);
 
     return app;

--- a/liteidex/src/liteapp/liteapp.h
+++ b/liteidex/src/liteapp/liteapp.h
@@ -159,6 +159,7 @@ protected:
 public:
     static QMap<QString,QVariant> s_cookie;
     static QList<IApplication*> s_appList;
+    static bool     s_darkMode; //app dark or light
 protected:
     QAction     *m_newAct;
     QAction     *m_openFileAct;

--- a/liteidex/src/liteapp/liteapp.pro
+++ b/liteidex/src/liteapp/liteapp.pro
@@ -75,6 +75,7 @@ SOURCES += main.cpp\
     folderprojectfactory.cpp \
     goproxy.cpp \
     htmlwidgetmanager.cpp \
+    thememanager.cpp \
     textbrowserhtmlwidget.cpp \
     splitwindowstyle.cpp \
     sidewindowstyle.cpp \
@@ -110,6 +111,7 @@ HEADERS  += mainwindow.h \
     goproxy.h \
     cdrv.h \
     htmlwidgetmanager.h \
+    thememanager.h \
     textbrowserhtmlwidget.h \
     windowstyle.h \
     splitwindowstyle.h \

--- a/liteidex/src/liteapp/liteapp_global.h
+++ b/liteidex/src/liteapp/liteapp_global.h
@@ -53,6 +53,7 @@
 #define LITEAPP_EDITTABSENABLEWHELL "LiteApp/EditTabEnableWhell"
 #define LITEAPP_SHOWEDITTOOLBAR "LiteApp/ShowEditToolbar"
 #define LITEAPP_QSS "LiteApp/Qss"
+#define LITEAPP_QSS_DARK "LiteApp/Qss_dark"
 #define LITEAPP_FULLSCREEN "LiteApp/FullScreen"
 #define LITEAPP_WINSTATE   "LiteApp/WinState"
 #define LITEAPP_SHORTCUTS "keybord_shortcuts/"

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -34,6 +34,8 @@
 #include <QMessageBox>
 #include <QDebug>
 
+#include "thememanager.h"
+
 //lite_memory_check_begin
 #if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
      #define _CRTDBG_MAP_ALLOC
@@ -150,67 +152,6 @@ QString LiteAppOption::mimeType() const
     return OPTION_LITEAPP;
 }
 
-bool guess_dark(QString qss){
-    // printf("--- guess_dark: %s\n", qss.toStdString().c_str());
-    QString dark_keywords[] = { "black", "dark", "night" };
-    QString dark_names[] = { "carbon", "detroit-future", "gray", "sublime" };
-
-    QString qss_lower = qss.toLower();
-
-    for (const QString &keyword : dark_keywords) {
-        if (qss_lower.contains(keyword)) {
-            // qDebug() << "= guess dark by keyword:" << keyword;
-            return true;
-        }
-    }
-    if (qss_lower.endsWith(".qss")) {
-        qss_lower.chop(4);
-    }
-    for (const QString &theme : dark_names) {
-        if (qss_lower == theme) {
-            // qDebug() << "= guess dark by name:" << theme;
-            return true;
-        }
-    }
-
-    return false;
-}
-
-extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
-
-void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp){
-    //----1.check if dark
-    bool is_dark = guess_dark(qss);
-    qDebug() << "--- auto_editor_theme guess_dark:" << qss << (is_dark ? "dark" : "light") << " //app:" << m_liteApp;
-
-    auto_editor_theme(is_dark, m_liteApp);
-}
-
-void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp){
-    //----1.check if dark
-    // bool is_dark = guess_dark(qss);
-    // qDebug() << "--- auto_editor_theme guess_dark:" << (is_dark ? "dark" : "light") << " //app:" << m_liteApp;
-
-    //----2.get editor settings
-    #define EDITOR_STYLE "editor/style"
-    #define EDITOR_STYLE_DARK "editor/style_dark"
-    QString styleName = m_liteApp->settings()->value(EDITOR_STYLE,"default.xml").toString();
-    QString styleName_dark = m_liteApp->settings()->value(EDITOR_STYLE_DARK,"NOT SET").toString();
-
-    //----3.apply editor theme
-    if (is_dark && styleName_dark != "NOT SET") {
-        // styleName = styleName_dark;
-        qDebug() << "=== auto_editor_theme dark:" << styleName_dark;
-        QString style = styleName_dark;
-        QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
-        m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
-    }else{
-        qDebug() << "=== auto_editor_theme light:" << styleName;
-        QString style = styleName;
-        QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
-        m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
-    }
-}
 
 void LiteAppOption::save()
 {
@@ -295,7 +236,8 @@ void LiteAppOption::save()
             qApp->setStyleSheet(styleSheet);
 
             //chen: auto editor theme
-            auto_editor_theme(qss, m_liteApp);
+            // auto_editor_theme(qss, m_liteApp);
+            ThemeManager::app_theme_changed(qss);
         }
     }
     // qss dark: save

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -102,6 +102,12 @@ LiteAppOption::LiteAppOption(LiteApi::IApplication *app,QObject *parent) :
         foreach (QFileInfo info, qssDir.entryInfoList(QStringList() << "*.qss")) {
             ui->qssComboBox->addItem(info.fileName());
         }
+
+        // qss dark: init
+        foreach (QFileInfo info, qssDir.entryInfoList(QStringList() << "*.qss")) {
+            ui->qssComboBox_dark->addItem(info.fileName());
+        }
+        ui->qssComboBox_dark->addItem(QString("NOT SET"));
     }
 
 //    if (libgopher.isValid()) {
@@ -282,6 +288,15 @@ void LiteAppOption::save()
             auto_editor_theme(qss, m_liteApp);
         }
     }
+    // qss dark: save
+    QString qss_dark = ui->qssComboBox_dark->currentText();
+    if (!qss_dark.isEmpty()) {        
+        m_liteApp->settings()->setValue(LITEAPP_QSS_DARK,qss_dark);
+
+        //chen: auto editor theme
+        // auto_editor_theme(qss, m_liteApp);
+    }
+    qDebug() << "=== save qss, qss_dark:" << qss << qss_dark;
 
     bool customelIcon = ui->customIconCheckBox->isChecked();
     m_liteApp->settings()->setValue(LITEIDE_CUSTOMEICON,customelIcon);
@@ -346,6 +361,13 @@ void LiteAppOption::load()
     if (index >= 0 && index < ui->qssComboBox->count()) {
         ui->qssComboBox->setCurrentIndex(index);
     }
+    //qss dark: load
+    QString qss_dark = m_liteApp->settings()->value(LITEAPP_QSS_DARK,"NOT SET").toString();
+    int index2 = ui->qssComboBox_dark->findText(qss_dark,Qt::MatchFixedString);
+    if (index2 >= 0 && index < ui->qssComboBox_dark->count()) {
+        ui->qssComboBox_dark->setCurrentIndex(index2);
+    }
+    qDebug() << "=== load qss, qss_dark:" << qss << qss_dark << index2;
 
     int max = m_liteApp->settings()->value(LITEAPP_MAXRECENTFILES,32).toInt();
     //ui->maxRecentLineEdit->setText(QString("%1").arg(max));

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -173,12 +173,27 @@ bool guess_dark(QString qss){
 void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp){
     //----1.check if dark
     bool is_dark = guess_dark(qss);
-    qDebug() << "auto_editor_theme:" << qss << "is_dark?" << is_dark;
+    qDebug() << "--- auto_editor_theme guess_dark:" << qss << (is_dark ? "dark" : "light");
 
-    //----2.apply editor theme (hard-coded theme)
-    QString style = is_dark? "sublime.xml": "visualstudio.xml";
-    QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
-    m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+    //----2.get editor settings
+    #define EDITOR_STYLE "editor/style"
+    #define EDITOR_STYLE_DARK "editor/style_dark"
+    QString styleName = m_liteApp->settings()->value(EDITOR_STYLE,"default.xml").toString();
+    QString styleName_dark = m_liteApp->settings()->value(EDITOR_STYLE_DARK,"NOT SET").toString();
+
+    //----3.apply editor theme
+    if (is_dark && styleName_dark != "NOT SET") {
+        // styleName = styleName_dark;
+        qDebug() << "=== auto_editor_theme dark:" << styleName_dark;
+        QString style = styleName_dark;
+        QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
+        m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+    }else{
+        qDebug() << "=== auto_editor_theme light:" << styleName;
+        QString style = styleName;
+        QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
+        m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+    }
 }
 
 void LiteAppOption::save()

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -176,10 +176,20 @@ bool guess_dark(QString qss){
     return false;
 }
 
+extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
+
 void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp){
     //----1.check if dark
     bool is_dark = guess_dark(qss);
-    qDebug() << "--- auto_editor_theme guess_dark:" << qss << (is_dark ? "dark" : "light");
+    qDebug() << "--- auto_editor_theme guess_dark:" << qss << (is_dark ? "dark" : "light") << " //app:" << m_liteApp;
+
+    auto_editor_theme(is_dark, m_liteApp);
+}
+
+void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp){
+    //----1.check if dark
+    // bool is_dark = guess_dark(qss);
+    // qDebug() << "--- auto_editor_theme guess_dark:" << (is_dark ? "dark" : "light") << " //app:" << m_liteApp;
 
     //----2.get editor settings
     #define EDITOR_STYLE "editor/style"

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -144,6 +144,43 @@ QString LiteAppOption::mimeType() const
     return OPTION_LITEAPP;
 }
 
+bool guess_dark(QString qss){
+    // printf("--- guess_dark: %s\n", qss.toStdString().c_str());
+    QString dark_keywords[] = { "black", "dark", "night" };
+    QString dark_names[] = { "carbon", "detroit-future", "gray", "sublime" };
+
+    QString qss_lower = qss.toLower();
+
+    for (const QString &keyword : dark_keywords) {
+        if (qss_lower.contains(keyword)) {
+            // qDebug() << "= guess dark by keyword:" << keyword;
+            return true;
+        }
+    }
+    if (qss_lower.endsWith(".qss")) {
+        qss_lower.chop(4);
+    }
+    for (const QString &theme : dark_names) {
+        if (qss_lower == theme) {
+            // qDebug() << "= guess dark by name:" << theme;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp){
+    //----1.check if dark
+    bool is_dark = guess_dark(qss);
+    qDebug() << "auto_editor_theme:" << qss << "is_dark?" << is_dark;
+
+    //----2.apply editor theme (hard-coded theme)
+    QString style = is_dark? "sublime.xml": "visualstudio.xml";
+    QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
+    m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+}
+
 void LiteAppOption::save()
 {
     bool storeLocal = ui->storeLocalCheckBox->isChecked();
@@ -225,6 +262,9 @@ void LiteAppOption::save()
             m_liteApp->settings()->setValue(LITEAPP_QSS,qss);
             QString styleSheet = QLatin1String(f.readAll());
             qApp->setStyleSheet(styleSheet);
+
+            //chen: auto editor theme
+            auto_editor_theme(qss, m_liteApp);
         }
     }
 

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -152,7 +152,6 @@ QString LiteAppOption::mimeType() const
     return OPTION_LITEAPP;
 }
 
-
 void LiteAppOption::save()
 {
     bool storeLocal = ui->storeLocalCheckBox->isChecked();
@@ -236,7 +235,6 @@ void LiteAppOption::save()
             qApp->setStyleSheet(styleSheet);
 
             //chen: auto editor theme
-            // auto_editor_theme(qss, m_liteApp);
             ThemeManager::app_theme_changed(qss);
         }
     }

--- a/liteidex/src/liteapp/liteappoption.cpp
+++ b/liteidex/src/liteapp/liteappoption.cpp
@@ -247,6 +247,7 @@ void LiteAppOption::save()
         // auto_editor_theme(qss, m_liteApp);
     }
     qDebug() << "=== save qss, qss_dark:" << qss << qss_dark;
+    // TODO: improve the dark/light settings UI
 
     bool customelIcon = ui->customIconCheckBox->isChecked();
     m_liteApp->settings()->setValue(LITEIDE_CUSTOMEICON,customelIcon);

--- a/liteidex/src/liteapp/liteappoption.ui
+++ b/liteidex/src/liteapp/liteappoption.ui
@@ -178,6 +178,45 @@
          </item>
         </layout>
        </item>
+
+       <!-- dark theme -->
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11_">
+         <item>
+          <widget class="QGroupBox" name="groupBox_6_">
+           <property name="title">
+            <string>Theme Dark</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_6_">
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Theme:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="qssComboBox_dark"/>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+
        <item>
         <widget class="QGroupBox" name="groupBox_10">
          <property name="title">

--- a/liteidex/src/liteapp/main.cpp
+++ b/liteidex/src/liteapp/main.cpp
@@ -93,14 +93,6 @@ private:
 };
 #endif
 
-
-
-//chen:
-// extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
-// extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
-// extern bool guess_dark(QString qss);
-
-
 #ifdef LITEAPP_LIBRARY
 int liteapp_main(int argc, char *argv[])
 #else
@@ -238,8 +230,6 @@ int main(int argc, char *argv[])
     //chen: auto editor theme
     ThemeManager themeManager(&app);
     ThemeManager::monit_system_theme(&app);
-    // auto_editor_theme(qss, liteApp);
-    // monit_system_theme_change(&app, liteApp);
 
     foreach(QString file, fileList) {
         QFileInfo f(file);

--- a/liteidex/src/liteapp/main.cpp
+++ b/liteidex/src/liteapp/main.cpp
@@ -95,6 +95,8 @@ private:
 
 //chen:
 extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
+extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
+extern bool guess_dark(QString qss);
 
 void auto_app_theme(QString qss, QApplication &app, LiteApi::IApplication *m_liteApp){
     // QFile f(resPath+"/liteapp/qss/"+qss);
@@ -103,8 +105,11 @@ void auto_app_theme(QString qss, QApplication &app, LiteApi::IApplication *m_lit
         QString styleSheet = QLatin1String(f.readAll());
         app.setStyleSheet(styleSheet);
     }
+ 
+    LiteApp::s_darkMode = guess_dark(qss);
+    auto_editor_theme(LiteApp::s_darkMode, m_liteApp);
 
-    auto_editor_theme(qss, m_liteApp);
+    // auto_editor_theme(qss, m_liteApp);
     // foreach(LiteApi::IApplication *liteApp, m_liteApp->appList()) {
     // foreach(LiteApi::IApplication *liteApp, m_liteApp->instanceList()) {
     //     qDebug() << " >>> auto_app_theme: - instance:" << liteApp;

--- a/liteidex/src/liteapp/main.cpp
+++ b/liteidex/src/liteapp/main.cpp
@@ -105,6 +105,11 @@ void auto_app_theme(QString qss, QApplication &app, LiteApi::IApplication *m_lit
     }
 
     auto_editor_theme(qss, m_liteApp);
+    // foreach(LiteApi::IApplication *liteApp, m_liteApp->appList()) {
+    // foreach(LiteApi::IApplication *liteApp, m_liteApp->instanceList()) {
+    //     qDebug() << " >>> auto_app_theme: - instance:" << liteApp;
+    //     auto_editor_theme(qss, liteApp);
+    // }
 }
 
 void monit_system_theme_change(QApplication *app, LiteApi::IApplication *m_liteApp){
@@ -132,18 +137,23 @@ void monit_system_theme_change(QApplication *app, LiteApi::IApplication *m_liteA
     }
 
     // 监听变化
-    QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app, m_liteApp]() {
+    // QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app, m_liteApp]() {
+    QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app]() {
         while (proc->canReadLine()) {
             QString line = QString::fromUtf8(proc->readLine()).trimmed();
             if (line.contains("color-scheme")) {
                 QString theme = line.section(' ', -1); // 取最后一个单词
 				theme = theme.remove("'");
                 qDebug() << "== system theme changed:" << theme;
+                // qDebug() << "== system theme changed:" << theme << m_liteApp;
 
                 bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
                 QString qss = is_dark ? "gray.qss" : "default.qss";
                 //------- 1. auto theme
-                auto_app_theme(qss, *app, m_liteApp);
+                // auto_app_theme(qss, *app, m_liteApp);
+                foreach(LiteApi::IApplication *liteApp, LiteApp::appList()) {
+                    auto_app_theme(qss, *app, liteApp);
+                }
             }
         }
     });

--- a/liteidex/src/liteapp/main.cpp
+++ b/liteidex/src/liteapp/main.cpp
@@ -90,6 +90,66 @@ private:
 };
 #endif
 
+
+#include <QProcess>
+
+//chen:
+extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
+
+void auto_app_theme(QString qss, QApplication &app, LiteApi::IApplication *m_liteApp){
+    // QFile f(resPath+"/liteapp/qss/"+qss);
+    QFile f(m_liteApp->resourcePath()+"/liteapp/qss/"+qss);
+    if (f.open(QFile::ReadOnly)) {
+        QString styleSheet = QLatin1String(f.readAll());
+        app.setStyleSheet(styleSheet);
+    }
+
+    auto_editor_theme(qss, m_liteApp);
+}
+
+void monit_system_theme_change(QApplication *app, LiteApi::IApplication *m_liteApp){
+    qDebug()<< "=== monit_system_theme_change...";
+
+    // 启动 gsettings monitor 进程
+	// gsettings monitor org.gnome.desktop.interface color-scheme
+    QProcess *proc = new QProcess(app);
+    proc->setProcessChannelMode(QProcess::MergedChannels);
+    proc->start("gsettings", {"monitor", "org.gnome.desktop.interface", "color-scheme"});
+
+    // 初始读取一次
+    {
+        QProcess getProc;
+        getProc.start("gsettings", {"get", "org.gnome.desktop.interface", "color-scheme"});
+        getProc.waitForFinished();
+        QString theme = getProc.readAllStandardOutput().trimmed();
+		theme = theme.remove("'");
+        qDebug() << "== system theme current:" << theme;
+
+        //----- 0. init theme
+        bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
+        QString qss = is_dark ? "gray.qss" : "default.qss";
+        auto_app_theme(qss, *app, m_liteApp);
+    }
+
+    // 监听变化
+    QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app, m_liteApp]() {
+        while (proc->canReadLine()) {
+            QString line = QString::fromUtf8(proc->readLine()).trimmed();
+            if (line.contains("color-scheme")) {
+                QString theme = line.section(' ', -1); // 取最后一个单词
+				theme = theme.remove("'");
+                qDebug() << "== system theme changed:" << theme;
+
+                bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
+                QString qss = is_dark ? "gray.qss" : "default.qss";
+                //------- 1. auto theme
+                auto_app_theme(qss, *app, m_liteApp);
+            }
+        }
+    });
+
+}
+
 #ifdef LITEAPP_LIBRARY
 int liteapp_main(int argc, char *argv[])
 #else
@@ -223,6 +283,10 @@ int main(int argc, char *argv[])
 #ifdef Q_OS_MACOS
     app.liteApp = liteApp;
 #endif
+
+    //chen: auto editor theme
+    auto_editor_theme(qss, liteApp);
+    monit_system_theme_change(&app, liteApp);
 
     foreach(QString file, fileList) {
         QFileInfo f(file);

--- a/liteidex/src/liteapp/main.cpp
+++ b/liteidex/src/liteapp/main.cpp
@@ -41,6 +41,9 @@
 #include "liteapp.h"
 #include "goproxy.h"
 #include "cdrv.h"
+
+#include "thememanager.h"
+
 //lite_memory_check_begin
 #if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
      #define _CRTDBG_MAP_ALLOC
@@ -91,79 +94,12 @@ private:
 #endif
 
 
-#include <QProcess>
 
 //chen:
-extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
-extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
-extern bool guess_dark(QString qss);
+// extern void auto_editor_theme(QString qss, LiteApi::IApplication *m_liteApp);
+// extern void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
+// extern bool guess_dark(QString qss);
 
-void auto_app_theme(QString qss, QApplication &app, LiteApi::IApplication *m_liteApp){
-    // QFile f(resPath+"/liteapp/qss/"+qss);
-    QFile f(m_liteApp->resourcePath()+"/liteapp/qss/"+qss);
-    if (f.open(QFile::ReadOnly)) {
-        QString styleSheet = QLatin1String(f.readAll());
-        app.setStyleSheet(styleSheet);
-    }
- 
-    LiteApp::s_darkMode = guess_dark(qss);
-    auto_editor_theme(LiteApp::s_darkMode, m_liteApp);
-
-    // auto_editor_theme(qss, m_liteApp);
-    // foreach(LiteApi::IApplication *liteApp, m_liteApp->appList()) {
-    // foreach(LiteApi::IApplication *liteApp, m_liteApp->instanceList()) {
-    //     qDebug() << " >>> auto_app_theme: - instance:" << liteApp;
-    //     auto_editor_theme(qss, liteApp);
-    // }
-}
-
-void monit_system_theme_change(QApplication *app, LiteApi::IApplication *m_liteApp){
-    qDebug()<< "=== monit_system_theme_change...";
-
-    // 启动 gsettings monitor 进程
-	// gsettings monitor org.gnome.desktop.interface color-scheme
-    QProcess *proc = new QProcess(app);
-    proc->setProcessChannelMode(QProcess::MergedChannels);
-    proc->start("gsettings", {"monitor", "org.gnome.desktop.interface", "color-scheme"});
-
-    // 初始读取一次
-    {
-        QProcess getProc;
-        getProc.start("gsettings", {"get", "org.gnome.desktop.interface", "color-scheme"});
-        getProc.waitForFinished();
-        QString theme = getProc.readAllStandardOutput().trimmed();
-		theme = theme.remove("'");
-        qDebug() << "== system theme current:" << theme;
-
-        //----- 0. init theme
-        bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
-        QString qss = is_dark ? "gray.qss" : "default.qss";
-        auto_app_theme(qss, *app, m_liteApp);
-    }
-
-    // 监听变化
-    // QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app, m_liteApp]() {
-    QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app]() {
-        while (proc->canReadLine()) {
-            QString line = QString::fromUtf8(proc->readLine()).trimmed();
-            if (line.contains("color-scheme")) {
-                QString theme = line.section(' ', -1); // 取最后一个单词
-				theme = theme.remove("'");
-                qDebug() << "== system theme changed:" << theme;
-                // qDebug() << "== system theme changed:" << theme << m_liteApp;
-
-                bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
-                QString qss = is_dark ? "gray.qss" : "default.qss";
-                //------- 1. auto theme
-                // auto_app_theme(qss, *app, m_liteApp);
-                foreach(LiteApi::IApplication *liteApp, LiteApp::appList()) {
-                    auto_app_theme(qss, *app, liteApp);
-                }
-            }
-        }
-    });
-
-}
 
 #ifdef LITEAPP_LIBRARY
 int liteapp_main(int argc, char *argv[])
@@ -300,8 +236,10 @@ int main(int argc, char *argv[])
 #endif
 
     //chen: auto editor theme
-    auto_editor_theme(qss, liteApp);
-    monit_system_theme_change(&app, liteApp);
+    ThemeManager themeManager(&app);
+    ThemeManager::monit_system_theme(&app);
+    // auto_editor_theme(qss, liteApp);
+    // monit_system_theme_change(&app, liteApp);
 
     foreach(QString file, fileList) {
         QFileInfo f(file);

--- a/liteidex/src/liteapp/thememanager.cpp
+++ b/liteidex/src/liteapp/thememanager.cpp
@@ -1,0 +1,252 @@
+
+#include <QApplication>
+#include <QObject>
+#include <QProcess>
+#include <QDebug>
+
+#include "liteapp.h"
+
+#ifndef Q_OS_LINUX
+  #define Q_OS_LINUX 11
+#endif
+
+class ThemeManager : public QObject {
+    Q_OBJECT
+
+public:
+    //single instance
+    static ThemeManager* instance(QObject *parent = nullptr) {
+        static ThemeManager* _instance = nullptr;
+        if (!_instance) {
+            _instance = new ThemeManager(parent);
+        }
+        return _instance;
+    }
+
+    explicit ThemeManager(QObject *parent = nullptr);
+
+    static bool system_dark_mode;
+    static bool app_dark_mode;
+    static QApplication *app;
+
+    static void monit_system_theme(QApplication *app);
+
+    static void app_theme_changed(QString qss);
+    static void editor_theme_changed();
+    static bool guess_app_theme_dark(QString qss);
+
+    static void apply_to_liteApp(LiteApp *liteApp);
+
+signals:
+    void system_theme_change(bool dark_mode);
+    void app_theme_change(bool dark_mode);
+
+public slots:
+    void setting_changed();
+    void system_theme_onchange(bool dark_mode);
+
+
+};
+
+// Static member initialization
+bool ThemeManager::system_dark_mode = false;
+bool ThemeManager::app_dark_mode = false;
+QApplication *ThemeManager::app;
+
+void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp);
+void auto_app_theme(bool is_dark, QApplication &app, LiteApi::IApplication *m_liteApp);
+
+ThemeManager::ThemeManager(QObject *parent) : QObject(parent) {
+
+}
+
+void ThemeManager::apply_to_liteApp(LiteApp *liteApp) {
+    if (!liteApp) return;
+
+    auto_editor_theme(LiteApp::s_darkMode, liteApp);
+}
+
+void ThemeManager::system_theme_onchange(bool dark_mode) {
+    foreach(LiteApi::IApplication *liteApp, LiteApp::appList()) {
+        // auto_app_theme(qss, *app, liteApp);
+        // auto_app_theme(dark_mode, *app, liteApp);
+        auto_app_theme(dark_mode, *ThemeManager::app, liteApp);
+    }
+}
+
+void ThemeManager::app_theme_changed(QString qss){
+    bool is_dark = guess_app_theme_dark(qss);
+    if (is_dark != app_dark_mode) {
+        app_dark_mode = is_dark;
+        emit instance()->app_theme_change(app_dark_mode);
+    }
+}
+void ThemeManager::editor_theme_changed(){
+    qDebug()<< "=== editor_thene_changed: need reload!";
+}
+
+bool ThemeManager::guess_app_theme_dark(QString qss){
+    // printf("--- guess_dark: %s\n", qss.toStdString().c_str());
+    QString dark_keywords[] = { "black", "dark", "night" };
+    QString dark_names[] = { "carbon", "detroit-future", "gray", "sublime" };
+
+    QString qss_lower = qss.toLower();
+
+    for (const QString &keyword : dark_keywords) {
+        if (qss_lower.contains(keyword)) {
+            // qDebug() << "= guess dark by keyword:" << keyword;
+            return true;
+        }
+    }
+    if (qss_lower.endsWith(".qss")) {
+        qss_lower.chop(4);
+    }
+    for (const QString &theme : dark_names) {
+        if (qss_lower == theme) {
+            // qDebug() << "= guess dark by name:" << theme;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void ThemeManager::monit_system_theme(QApplication *app) {
+// void ThemeManager::monit_system_theme(QObject *app) {
+    // monitor system theme and emit signal if changed
+
+    ThemeManager::app = app;
+
+#if defined(Q_OS_LINUX)
+
+    qDebug()<< "=== monit_system_theme_change...";
+
+    // 启动 gsettings monitor 进程
+	// gsettings monitor org.gnome.desktop.interface color-scheme
+    QProcess *proc = new QProcess(app);
+    proc->setProcessChannelMode(QProcess::MergedChannels);
+    proc->start("gsettings", {"monitor", "org.gnome.desktop.interface", "color-scheme"});
+
+    // 初始读取一次
+    {
+        QProcess getProc;
+        getProc.start("gsettings", {"get", "org.gnome.desktop.interface", "color-scheme"});
+        getProc.waitForFinished();
+        QString theme = getProc.readAllStandardOutput().trimmed();
+		theme = theme.remove("'");
+        qDebug() << "== system theme current:" << theme;
+
+        //----- 0. init theme
+        bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
+        system_dark_mode = is_dark;
+        // emit instance()->system_theme_change(system_dark_mode);
+        instance()->system_theme_onchange(system_dark_mode);
+    }
+
+    // 监听变化
+    QObject::connect(proc, &QProcess::readyReadStandardOutput, app, [proc, app]() {
+        while (proc->canReadLine()) {
+            QString line = QString::fromUtf8(proc->readLine()).trimmed();
+            if (line.contains("color-scheme")) {
+                QString theme = line.section(' ', -1); // 取最后一个单词
+				theme = theme.remove("'");
+                qDebug() << "== system theme changed:" << theme;
+
+                bool is_dark = theme.contains("dark", Qt::CaseInsensitive);
+
+                bool new_mode = is_dark;
+                if (new_mode != system_dark_mode) {
+                    system_dark_mode = new_mode;
+                    // emit instance()->system_theme_change(system_dark_mode);
+
+                    instance()->system_theme_onchange(system_dark_mode);
+                }
+            }
+        }
+    });
+
+#elif defined(Q_OS_WIN)
+
+#elif defined(Q_OS_MAC)
+
+#else
+
+#endif
+}
+
+
+bool guess_dark(QString qss){
+    // printf("--- guess_dark: %s\n", qss.toStdString().c_str());
+    QString dark_keywords[] = { "black", "dark", "night" };
+    QString dark_names[] = { "carbon", "detroit-future", "gray", "sublime" };
+
+    QString qss_lower = qss.toLower();
+
+    for (const QString &keyword : dark_keywords) {
+        if (qss_lower.contains(keyword)) {
+            // qDebug() << "= guess dark by keyword:" << keyword;
+            return true;
+        }
+    }
+    if (qss_lower.endsWith(".qss")) {
+        qss_lower.chop(4);
+    }
+    for (const QString &theme : dark_names) {
+        if (qss_lower == theme) {
+            // qDebug() << "= guess dark by name:" << theme;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void auto_editor_theme(bool is_dark , LiteApi::IApplication *m_liteApp){
+    //----1.check if dark
+    // bool is_dark = guess_dark(qss);
+    // qDebug() << "--- auto_editor_theme guess_dark:" << (is_dark ? "dark" : "light") << " //app:" << m_liteApp;
+
+    //----2.get editor settings
+    #define EDITOR_STYLE "editor/style"
+    #define EDITOR_STYLE_DARK "editor/style_dark"
+    QString styleName = m_liteApp->settings()->value(EDITOR_STYLE,"default.xml").toString();
+    QString styleName_dark = m_liteApp->settings()->value(EDITOR_STYLE_DARK,"NOT SET").toString();
+
+    //----3.apply editor theme
+    if (is_dark && styleName_dark != "NOT SET") {
+        // styleName = styleName_dark;
+        qDebug() << "=== auto_editor_theme dark:" << styleName_dark;
+        QString style = styleName_dark;
+        QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
+        m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+    }else{
+        qDebug() << "=== auto_editor_theme light:" << styleName;
+        QString style = styleName;
+        QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
+        m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+    }
+}
+
+void auto_app_theme(QString qss, QApplication &app, LiteApi::IApplication *m_liteApp){
+    // QFile f(resPath+"/liteapp/qss/"+qss);
+    QFile f(m_liteApp->resourcePath()+"/liteapp/qss/"+qss);
+    if (f.open(QFile::ReadOnly)) {
+        QString styleSheet = QLatin1String(f.readAll());
+        app.setStyleSheet(styleSheet);
+    }
+
+    LiteApp::s_darkMode = guess_dark(qss);
+    auto_editor_theme(LiteApp::s_darkMode, m_liteApp);
+
+    // auto_editor_theme(qss, m_liteApp);
+    // foreach(LiteApi::IApplication *liteApp, m_liteApp->appList()) {
+    // foreach(LiteApi::IApplication *liteApp, m_liteApp->instanceList()) {
+    //     qDebug() << " >>> auto_app_theme: - instance:" << liteApp;
+    //     auto_editor_theme(qss, liteApp);
+    // }
+}
+
+void auto_app_theme(bool is_dark, QApplication &app, LiteApi::IApplication *m_liteApp){
+    QString qss = is_dark ? "gray.qss" : "default.qss";
+    auto_app_theme(qss, app, m_liteApp);
+}

--- a/liteidex/src/liteapp/thememanager.cpp
+++ b/liteidex/src/liteapp/thememanager.cpp
@@ -1,4 +1,7 @@
 
+// Module: thememanager.cpp
+// Creator: yurenchen
+
 #include <QApplication>
 #include <QObject>
 #include <QProcess>
@@ -118,7 +121,8 @@ void ThemeManager::monit_system_theme(QApplication *app) {
     ThemeManager::app = app;
 
 #if defined(Q_OS_LINUX)
-
+    // TODO: implement it for other desktop environment (currently only gnome is supported)
+    // TODO: improve it without run a gsettings process (currently need gsettings cmd)
     qDebug()<< "=== monit_system_theme_change...";
 
     // 启动 gsettings monitor 进程
@@ -166,9 +170,9 @@ void ThemeManager::monit_system_theme(QApplication *app) {
     });
 
 #elif defined(Q_OS_WIN)
-
+    // TODO: implement it for windows11
 #elif defined(Q_OS_MAC)
-
+    // TODO: implement it for macos
 #else
 
 #endif

--- a/liteidex/src/liteapp/thememanager.h
+++ b/liteidex/src/liteapp/thememanager.h
@@ -1,3 +1,7 @@
+
+// Module: thememanager.cpp
+// Creator: yurenchen
+
 #pragma once
 
 #include <QObject>

--- a/liteidex/src/liteapp/thememanager.h
+++ b/liteidex/src/liteapp/thememanager.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QApplication>
+
+#include "liteapp.h"
+
+class ThemeManager : public QObject {
+    Q_OBJECT
+
+public:
+    static ThemeManager* instance(QObject *parent = nullptr);
+
+    explicit ThemeManager(QObject *parent = nullptr);
+
+    static bool system_dark_mode;
+    static bool app_dark_mode;
+
+    //init
+    static void monit_system_theme(QApplication *app);
+    
+    //call when change
+    static void app_theme_changed(QString qss);
+    static void editor_theme_changed();
+
+    //call when liteApp created
+    static void apply_to_liteApp(LiteApp *liteApp);
+private:
+    static bool guess_app_theme_dark(QString qss);
+
+signals:
+    void system_theme_change(bool dark_mode);
+    void app_theme_change(bool dark_mode);
+
+public slots:
+    void setting_changed();
+};

--- a/liteidex/src/plugins/liteeditor/liteeditor_global.h
+++ b/liteidex/src/plugins/liteeditor/liteeditor_global.h
@@ -41,6 +41,7 @@
 
 #define OPTION_LITEEDITOR "option/liteeditor"
 #define EDITOR_STYLE "editor/style"
+#define EDITOR_STYLE_DARK "editor/style_dark"
 #define EDITOR_FAMILY "editor/family"
 #define EDITOR_FONTSIZE "editor/fontsize"
 #define EDITOR_FONTZOOM "editor/fontzoom"

--- a/liteidex/src/plugins/liteeditor/liteeditoroption.cpp
+++ b/liteidex/src/plugins/liteeditor/liteeditoroption.cpp
@@ -143,6 +143,7 @@ void LiteEditorOption::save()
     if(theme_changed){
         ThemeManager::editor_theme_changed();
     }
+    // TODO: improve the dark/light settings UI
 
     bool noprintCheck = ui->noprintCheckBox->isChecked();
     bool autoIndent = ui->autoIndentCheckBox->isChecked();

--- a/liteidex/src/plugins/liteeditor/liteeditoroption.cpp
+++ b/liteidex/src/plugins/liteeditor/liteeditoroption.cpp
@@ -30,6 +30,7 @@
 #include <QFileInfo>
 #include <QStandardItemModel>
 #include <QStandardItem>
+#include <QDebug>
 
 //lite_memory_check_begin
 #if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
@@ -127,6 +128,12 @@ void LiteEditorOption::save()
         m_liteApp->settings()->setValue(EDITOR_STYLE,style);
         QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
         m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+    }
+    // CHEN: save style_dark
+    QString style_dark = ui->styleComboBox_dark->currentText();
+    if (style_dark != m_liteApp->settings()->value(EDITOR_STYLE_DARK,"NOT SET").toString()) {
+        m_liteApp->settings()->setValue(EDITOR_STYLE_DARK,style_dark);
+        qDebug() << "=== editor_dark_theme save:" << style_dark;
     }
 
     bool noprintCheck = ui->noprintCheckBox->isChecked();
@@ -229,23 +236,39 @@ void LiteEditorOption::load()
 
     ui->fontZoomSpinBox->setValue(fontZoom);
 
+    //CHEN: load style_dark
+    QString styleName_dark = m_liteApp->settings()->value(EDITOR_STYLE_DARK,"NOT SET").toString();
     QString styleName = m_liteApp->settings()->value(EDITOR_STYLE,"default.xml").toString();
     QString stylePath = m_liteApp->resourcePath()+"/liteeditor/color";
     QDir dir(stylePath);
+    int index_dark = -1;
     int index = -1;
     if (!QFileInfo(stylePath,styleName).exists()) {
         styleName = "default.xml";
     }
+
+    //----- CHEN: 加载可选 editor theme
     ui->styleComboBox->clear();
+    ui->styleComboBox_dark->clear();
     foreach(QFileInfo info, dir.entryInfoList(QStringList() << "*.xml")) {
         ui->styleComboBox->addItem(info.fileName());
+        ui->styleComboBox_dark->addItem(info.fileName());
         if (info.fileName() == styleName) {
             index = ui->styleComboBox->count()-1;
+        }
+        if (info.fileName() == styleName_dark) {
+            index_dark = ui->styleComboBox_dark->count()-1;
         }
     }
     if (index >= 0 && index < ui->styleComboBox->count()) {
         ui->styleComboBox->setCurrentIndex(index);
     }
+    if (index_dark >= 0 && index_dark < ui->styleComboBox_dark->count()) {
+        ui->styleComboBox_dark->setCurrentIndex(index_dark);
+    }
+    ui->styleComboBox_dark->addItem("NOT SET");
+    qDebug() << "=== editor_dark_theme load:" << styleName_dark;
+
     bool noprintCheck = m_liteApp->settings()->value(EDITOR_NOPRINTCHECK,true).toBool();
     bool autoIndent = m_liteApp->settings()->value(EDITOR_AUTOINDENT,true).toBool();
     bool autoBraces0 = m_liteApp->settings()->value(EDITOR_AUTOBRACE0,true).toBool();

--- a/liteidex/src/plugins/liteeditor/liteeditoroption.cpp
+++ b/liteidex/src/plugins/liteeditor/liteeditoroption.cpp
@@ -32,6 +32,8 @@
 #include <QStandardItem>
 #include <QDebug>
 
+#include "../liteapp/thememanager.h"
+
 //lite_memory_check_begin
 #if defined(WIN32) && defined(_MSC_VER) &&  defined(_DEBUG)
      #define _CRTDBG_MAP_ALLOC
@@ -124,16 +126,22 @@ void LiteEditorOption::save()
     m_liteApp->settings()->setValue(EDITOR_FONTZOOM,fontZoom);
 
     QString style = ui->styleComboBox->currentText();
+    bool theme_changed = false;
     if (style != m_liteApp->settings()->value(EDITOR_STYLE,"default.xml").toString()) {
         m_liteApp->settings()->setValue(EDITOR_STYLE,style);
         QString styleFile = m_liteApp->resourcePath()+"/liteeditor/color/"+style;
         m_liteApp->editorManager()->loadColorStyleScheme(styleFile);
+        theme_changed = true;
     }
     // CHEN: save style_dark
     QString style_dark = ui->styleComboBox_dark->currentText();
     if (style_dark != m_liteApp->settings()->value(EDITOR_STYLE_DARK,"NOT SET").toString()) {
         m_liteApp->settings()->setValue(EDITOR_STYLE_DARK,style_dark);
         qDebug() << "=== editor_dark_theme save:" << style_dark;
+        theme_changed = true;
+    }
+    if(theme_changed){
+        ThemeManager::editor_theme_changed();
     }
 
     bool noprintCheck = ui->noprintCheckBox->isChecked();

--- a/liteidex/src/plugins/liteeditor/liteeditoroption.ui
+++ b/liteidex/src/plugins/liteeditor/liteeditoroption.ui
@@ -191,6 +191,47 @@
             </item>
            </layout>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_34">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Dark:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="styleComboBox_dark">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="editPushButton">
+              <property name="text">
+               <string>Edit</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>37</width>
+                <height>17</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
https://github.com/visualfc/liteide/issues/1333

- ➊ editor theme follow app theme
- ➋ app theme follow system theme // currently only support linux, gnome
   - TODO: implement system theme monitor for win, mac..
   - TODO: improve light-dark-theme setttings UI more natural
