### PR TITLE
Update installation guide for OpenBSD

### DIFF
--- a/liteidex/deploy/welcome/en/install.md
+++ b/liteidex/deploy/welcome/en/install.md
@@ -142,10 +142,12 @@ Use brew install qt (eg brew install qt. Other versions of qt@5.5 and qt@5.7 wor
 Warning! brew install qt rpath incorrect do not use deploy script. 
 
 ### OpenBSD
+	$ doas pkg_add go qt5
 	$ git clone https://github.com/visualfc/liteide.git
-	$ export QTDIR=/usr/local/lib/qt4
 	$ cd liteide/build
 	$ ./update_pkg.sh
+	$ export CXX="c++ -std=c++14"
+	$ export MAKEFLAGS="-j$(sysctl -n hw.ncpu)"
 	$ ./build_openbsd.sh
 
 	## Run it: ##


### PR DESCRIPTION
The goal of this PR is to update the installation guide for OpenBSD. It's tested for on OpenBSD 7.7 and 7.8.