### PR TITLE
gopls: make completion and navigation optional

### DIFF
--- a/liteidex/src/plugins/golangcode/golangcode.cpp
+++ b/liteidex/src/plugins/golangcode/golangcode.cpp
@@ -63,8 +63,7 @@ GolangCode::GolangCode(LiteApi::IApplication *app, QObject *parent) :
     m_editor(0),
     m_completer(0),
     m_closeOnExit(true),
-    m_allImportHint(true),
-    m_gocodeEnabled(true)
+    m_allImportHint(true)
 {
     g_gocodeInstCount++;
     m_gocodeProcess = new Process(this);
@@ -543,7 +542,7 @@ void GolangCode::setCompleter(LiteApi::ICompleter *completer)
     m_completer = completer;
     if (m_completer) {
         m_completer->setImportList(m_allImportList);
-        if (m_gocodeEnabled && !m_gocodeCmd.isEmpty()) {
+        if (!m_gocodeCmd.isEmpty()) {
             m_completer->setSearchSeparator(false);
             m_completer->setExternalMode(true);
             connect(m_completer,SIGNAL(prefixChanged(QTextCursor,QString,bool)),this,SLOT(prefixChanged(QTextCursor,QString,bool)));
@@ -555,20 +554,8 @@ void GolangCode::setCompleter(LiteApi::ICompleter *completer)
     }
 }
 
-void GolangCode::setGocodeEnabled(bool enabled)
-{
-    if (m_gocodeEnabled == enabled) {
-        return;
-    }
-    m_gocodeEnabled = enabled;
-    setCompleter(m_completer);
-}
-
 void GolangCode::prefixChanged(QTextCursor cur,QString pre,bool force)
 {
-    if (!m_gocodeEnabled) {
-        return;
-    }
     if (m_completer->completionContext() != LiteApi::CompleterCodeContext) {
         return;
     }

--- a/liteidex/src/plugins/golangcode/golangcode.h
+++ b/liteidex/src/plugins/golangcode/golangcode.h
@@ -71,7 +71,6 @@ public:
     void loadPkgList();
 //    void loadImportsList(const QProcessEnvironment &env);
 public slots:
-    void setGocodeEnabled(bool enabled);
     void currentEditorChanged(LiteApi::IEditor*);
     void currentEnvChanged(LiteApi::IEnv*);
     void prefixChanged(QTextCursor,QString,bool froce);
@@ -117,7 +116,6 @@ protected:
     QString     m_lastGopathEnv;
     bool        m_closeOnExit;
     bool        m_allImportHint;
-    bool        m_gocodeEnabled;
 };
 
 #endif // GOLANGCODE_H

--- a/liteidex/src/plugins/gopls/gopls.pro
+++ b/liteidex/src/plugins/gopls/gopls.pro
@@ -10,8 +10,15 @@ include (../../utils/fileutil/fileutil.pri)
 
 SOURCES += goplsplugin.cpp \
     goplsclient.cpp \
-    goplssearchresults.cpp
+    goplssearchresults.cpp \
+    goplsoption.cpp \
+    goplsoptionfactory.cpp
 
 HEADERS += goplsplugin.h \
     goplsclient.h \
-    goplssearchresults.h
+    goplssearchresults.h \
+    gopls_global.h \
+    goplsoption.h \
+    goplsoptionfactory.h
+
+FORMS += goplsoption.ui

--- a/liteidex/src/plugins/gopls/gopls_global.h
+++ b/liteidex/src/plugins/gopls/gopls_global.h
@@ -1,0 +1,7 @@
+#ifndef GOPLS_GLOBAL_H
+#define GOPLS_GLOBAL_H
+
+#define GOPLS_USE_FEATURES "gopls/usefeatures"
+#define OPTION_GOPLS "option/gopls"
+
+#endif // GOPLS_GLOBAL_H

--- a/liteidex/src/plugins/gopls/goplsoption.cpp
+++ b/liteidex/src/plugins/gopls/goplsoption.cpp
@@ -1,0 +1,29 @@
+#include "goplsoption.h"
+#include "gopls_global.h"
+#include "ui_goplsoption.h"
+
+GoplsOption::GoplsOption(LiteApi::IApplication *app, QObject *parent)
+    : LiteApi::IOption(parent), m_liteApp(app), m_widget(new QWidget), ui(new Ui::GoplsOption)
+{
+    ui->setupUi(m_widget);
+}
+
+GoplsOption::~GoplsOption()
+{
+    delete ui;
+    delete m_widget;
+}
+
+QWidget *GoplsOption::widget() { return m_widget; }
+QString GoplsOption::name() const { return "Gopls"; }
+QString GoplsOption::mimeType() const { return OPTION_GOPLS; }
+
+void GoplsOption::load()
+{
+    ui->enableCheckBox->setChecked(m_liteApp->settings()->value(GOPLS_USE_FEATURES, false).toBool());
+}
+
+void GoplsOption::save()
+{
+    m_liteApp->settings()->setValue(GOPLS_USE_FEATURES, ui->enableCheckBox->isChecked());
+}

--- a/liteidex/src/plugins/gopls/goplsoption.h
+++ b/liteidex/src/plugins/gopls/goplsoption.h
@@ -1,0 +1,25 @@
+#ifndef GOPLSOPTION_H
+#define GOPLSOPTION_H
+
+#include "liteapi/liteapi.h"
+
+namespace Ui { class GoplsOption; }
+
+class GoplsOption : public LiteApi::IOption
+{
+    Q_OBJECT
+public:
+    explicit GoplsOption(LiteApi::IApplication *app, QObject *parent = 0);
+    ~GoplsOption();
+    QWidget *widget();
+    QString name() const;
+    QString mimeType() const;
+    void load();
+    void save();
+private:
+    LiteApi::IApplication *m_liteApp;
+    QWidget *m_widget;
+    Ui::GoplsOption *ui;
+};
+
+#endif // GOPLSOPTION_H

--- a/liteidex/src/plugins/gopls/goplsoption.ui
+++ b/liteidex/src/plugins/gopls/goplsoption.ui
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GoplsOption</class>
+ <widget class="QWidget" name="GoplsOption">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title"><string>Gopls</string></property>
+     <layout class="QVBoxLayout" name="groupLayout">
+      <item>
+       <widget class="QCheckBox" name="enableCheckBox">
+        <property name="text"><string>Use gopls for code completion, mouse information and navigation</string></property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item><spacer name="verticalSpacer"><property name="orientation"><enum>Qt::Vertical</enum></property><property name="sizeHint" stdset="0"><size><width>20</width><height>40</height></size></property></spacer></item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/liteidex/src/plugins/gopls/goplsoptionfactory.cpp
+++ b/liteidex/src/plugins/gopls/goplsoptionfactory.cpp
@@ -1,0 +1,13 @@
+#include "goplsoption.h"
+#include "goplsoptionfactory.h"
+#include "gopls_global.h"
+
+GoplsOptionFactory::GoplsOptionFactory(LiteApi::IApplication *app, QObject *parent)
+    : LiteApi::IOptionFactory(parent), m_liteApp(app) {}
+
+QStringList GoplsOptionFactory::mimeTypes() const { return QStringList() << OPTION_GOPLS; }
+
+LiteApi::IOption *GoplsOptionFactory::create(const QString &mimeType)
+{
+    return mimeType == OPTION_GOPLS ? new GoplsOption(m_liteApp, this) : 0;
+}

--- a/liteidex/src/plugins/gopls/goplsoptionfactory.h
+++ b/liteidex/src/plugins/gopls/goplsoptionfactory.h
@@ -1,0 +1,17 @@
+#ifndef GOPLSOPTIONFACTORY_H
+#define GOPLSOPTIONFACTORY_H
+
+#include "liteapi/liteapi.h"
+
+class GoplsOptionFactory : public LiteApi::IOptionFactory
+{
+    Q_OBJECT
+public:
+    explicit GoplsOptionFactory(LiteApi::IApplication *app, QObject *parent = 0);
+    QStringList mimeTypes() const;
+    LiteApi::IOption *create(const QString &mimeType);
+private:
+    LiteApi::IApplication *m_liteApp;
+};
+
+#endif // GOPLSOPTIONFACTORY_H

--- a/liteidex/src/plugins/gopls/goplsplugin.cpp
+++ b/liteidex/src/plugins/gopls/goplsplugin.cpp
@@ -5,6 +5,8 @@
 #include "golangastapi/golangastapi.h"
 #include "liteeditorapi/liteeditorapi.h"
 #include "fileutil/fileutil.h"
+#include "gopls_global.h"
+#include "goplsoptionfactory.h"
 
 #include <QCoreApplication>
 #include <QApplication>
@@ -26,7 +28,7 @@
 
 GoplsPlugin::GoplsPlugin() : m_liteApp(0), m_client(0), m_completer(0), m_ready(false),
     m_searchResults(0), m_definitionAction(0), m_referencesAction(0), m_implementationAction(0)
-    , m_renameAction(0), m_formatAction(0), m_organizeImportsAction(0), m_appLoaded(false)
+    , m_renameAction(0), m_formatAction(0), m_organizeImportsAction(0), m_appLoaded(false), m_useFeatures(false)
 {
 }
 
@@ -41,6 +43,8 @@ GoplsPlugin::~GoplsPlugin()
 bool GoplsPlugin::load(LiteApi::IApplication *app)
 {
     m_liteApp = app;
+    m_useFeatures = app->settings()->value(GOPLS_USE_FEATURES,false).toBool();
+    app->optionManager()->addFactory(new GoplsOptionFactory(app,this));
     m_client = new GoplsClient(this);
     m_searchResults = new GoplsSearchResults(this);
     LiteApi::IFileSearchManager *searchManager = LiteApi::getFileSearchManager(app);
@@ -54,6 +58,9 @@ bool GoplsPlugin::load(LiteApi::IApplication *app)
     m_renameAction = new QAction(tr("Rename Symbol (gopls)"),this);
     m_formatAction = new QAction(tr("Format Document (gopls)"),this);
     m_organizeImportsAction = new QAction(tr("Organize Imports (gopls)"),this);
+    m_definitionAction->setEnabled(m_useFeatures);
+    m_referencesAction->setEnabled(m_useFeatures);
+    m_implementationAction->setEnabled(m_useFeatures);
     actions->regAction(m_definitionAction,"Definition","");
     actions->regAction(m_referencesAction,"References","");
     actions->regAction(m_implementationAction,"Implementation","");
@@ -67,7 +74,8 @@ bool GoplsPlugin::load(LiteApi::IApplication *app)
     connect(m_formatAction,SIGNAL(triggered()),this,SLOT(formatDocument()));
     connect(m_organizeImportsAction,SIGNAL(triggered()),this,SLOT(organizeImports()));
     app->extension()->addObject("LiteApi.IGoplsService",m_client);
-    //connect(app,SIGNAL(loaded()),this,SLOT(appLoaded()));
+    connect(app,SIGNAL(loaded()),this,SLOT(appLoaded()));
+    connect(app->optionManager(),SIGNAL(applyOption(QString)),this,SLOT(applyOption(QString)));
     connect(m_client,SIGNAL(initialized()),this,SLOT(clientInitialized()));
     connect(m_client,SIGNAL(stopped()),this,SLOT(clientStopped()));
     connect(m_client,SIGNAL(logMessage(QString,bool)),this,SLOT(clientLog(QString,bool)));
@@ -78,7 +86,7 @@ bool GoplsPlugin::load(LiteApi::IApplication *app)
     connect(app->editorManager(),SIGNAL(currentEditorChanged(LiteApi::IEditor*)),this,SLOT(currentEditorChanged(LiteApi::IEditor*)));
     connect(app->editorManager(),SIGNAL(editorAboutToClose(LiteApi::IEditor*)),this,SLOT(editorAboutToClose(LiteApi::IEditor*)));
     connect(app->editorManager(),SIGNAL(editorSaved(LiteApi::IEditor*)),this,SLOT(editorSaved(LiteApi::IEditor*)));
-    //connect(app->projectManager(),SIGNAL(currentProjectChanged(LiteApi::IProject*)),this,SLOT(workspaceChanged()));
+    connect(app->projectManager(),SIGNAL(currentProjectChanged(LiteApi::IProject*)),this,SLOT(workspaceChanged()));
     LiteApi::IEnvManager *envManager = LiteApi::getEnvManager(app);
     if (envManager) {
         connect(envManager,SIGNAL(currentEnvChanged(LiteApi::IEnv*)),this,SLOT(environmentChanged(LiteApi::IEnv*)));
@@ -94,7 +102,7 @@ QStringList GoplsPlugin::dependPluginList() const
 bool GoplsPlugin::eventFilter(QObject *object, QEvent *event)
 {
     LiteApi::IEditor *editor = m_hoverViewports.value(object);
-    if (!m_ready || !editor || event->type() != QEvent::ToolTip) {
+    if (!m_useFeatures || !m_ready || !editor || event->type() != QEvent::ToolTip) {
         return LiteApi::IPlugin::eventFilter(object,event);
     }
     if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
@@ -134,6 +142,9 @@ QString GoplsPlugin::workspaceRoot() const
 void GoplsPlugin::appLoaded()
 {
     m_appLoaded = true;
+    if (!m_useFeatures) {
+        return;
+    }
     if (m_client->isRunning()) {
         return;
     }
@@ -172,7 +183,6 @@ void GoplsPlugin::clientInitialized()
 {
     m_ready = true;
     m_liteApp->appendLog("Gopls",tr("gopls initialized"));
-    setLegacyCompletionEnabled(false);
     foreach (LiteApi::IEditor *editor, m_liteApp->editorManager()->editorList()) {
         editorCreated(editor);
         openDocument(editor);
@@ -188,6 +198,7 @@ void GoplsPlugin::clientStopped()
         LiteApi::IEditor *editor = m_liteApp->editorManager()->currentEditor();
         if (editor) {
             configureCompleter(editor,false);
+            configureGocodeCompletion(editor,true);
         }
         m_completer = 0;
     }
@@ -196,23 +207,11 @@ void GoplsPlugin::clientStopped()
     m_completionRoots.clear();
     m_pendingCompletions.clear();
     m_pendingHovers.clear();
-    setLegacyCompletionEnabled(true);
 }
 
 void GoplsPlugin::clientLog(const QString &message, bool error)
 {
     m_liteApp->appendLog("Gopls",message,error);
-}
-
-void GoplsPlugin::setLegacyCompletionEnabled(bool enabled)
-{
-    if (!m_liteApp || !m_liteApp->extension()) {
-        return;
-    }
-    QObject *golangCode = m_liteApp->extension()->findObject("LiteApi.GolangCode");
-    if (golangCode) {
-        QMetaObject::invokeMethod(golangCode,"setGocodeEnabled",Qt::DirectConnection,Q_ARG(bool,enabled));
-    }
 }
 
 bool GoplsPlugin::isGoEditor(LiteApi::IEditor *editor) const
@@ -258,7 +257,7 @@ void GoplsPlugin::currentEditorChanged(LiteApi::IEditor *editor)
         return;
     }
     m_completer = LiteApi::findExtensionObject<LiteApi::ICompleter*>(editor,"LiteApi.ICompleter");
-    configureCompleter(editor,m_completer != 0);
+    configureCompleter(editor,m_useFeatures && m_completer != 0);
 }
 
 void GoplsPlugin::openDocument(LiteApi::IEditor *editor)
@@ -368,6 +367,7 @@ void GoplsPlugin::configureCompleter(LiteApi::IEditor *editor, bool enabled)
     disconnect(completer,SIGNAL(prefixChanged(QTextCursor,QString,bool)),this,SLOT(completionRequested(QTextCursor,QString,bool)));
     disconnect(completer,SIGNAL(wordCompleted(QString,QString,QString)),this,SLOT(completionAccepted(QString,QString,QString)));
     if (enabled) {
+        configureGocodeCompletion(editor,false);
         completer->setSearchSeparator(false);
         completer->setExternalMode(true);
         connect(completer,SIGNAL(prefixChanged(QTextCursor,QString,bool)),this,SLOT(completionRequested(QTextCursor,QString,bool)),Qt::UniqueConnection);
@@ -378,10 +378,64 @@ void GoplsPlugin::configureCompleter(LiteApi::IEditor *editor, bool enabled)
     }
 }
 
+void GoplsPlugin::configureGocodeCompletion(LiteApi::IEditor *editor, bool enabled)
+{
+    if (!editor || !m_liteApp || !m_liteApp->extension()) return;
+    QObject *golangCode = m_liteApp->extension()->findObject("LiteApi.GolangCode");
+    if (!golangCode) return;
+    LiteApi::ICompleter *completer = LiteApi::findExtensionObject<LiteApi::ICompleter*>(editor,"LiteApi.ICompleter");
+    if (!completer) return;
+    if (enabled) {
+        QMetaObject::invokeMethod(golangCode,"currentEditorChanged",Qt::DirectConnection,
+                                  Q_ARG(LiteApi::IEditor*,editor));
+    } else {
+        QObject::disconnect(completer,SIGNAL(prefixChanged(QTextCursor,QString,bool)),
+                            golangCode,SLOT(prefixChanged(QTextCursor,QString,bool)));
+        QObject::disconnect(completer,SIGNAL(wordCompleted(QString,QString,QString)),
+                            golangCode,SLOT(wordCompleted(QString,QString,QString)));
+    }
+}
+
+void GoplsPlugin::applyOption(const QString &option)
+{
+    if (option != OPTION_GOPLS) return;
+    bool enabled = m_liteApp->settings()->value(GOPLS_USE_FEATURES,false).toBool();
+    if (enabled == m_useFeatures) return;
+    m_useFeatures = enabled;
+    LiteApi::IEditor *editor = m_liteApp->editorManager()->currentEditor();
+    if (editor) {
+        configureCompleter(editor, enabled && m_completer != 0);
+        if (!enabled) configureGocodeCompletion(editor,true);
+    }
+    if (!enabled) {
+        foreach (int id, m_pendingCompletions) {
+            m_client->notify("$/cancelRequest",QJsonObject{{"id",id}});
+        }
+        m_pendingCompletions.clear();
+        m_completionEditors.clear();
+        m_completionPrefixes.clear();
+        m_completionRoots.clear();
+        foreach (int id, m_pendingHovers) {
+            m_client->notify("$/cancelRequest",QJsonObject{{"id",id}});
+        }
+        m_pendingHovers.clear();
+        m_hintEditors.clear();
+        m_hintPositions.clear();
+    }
+    m_definitionAction->setEnabled(enabled);
+    m_referencesAction->setEnabled(enabled);
+    m_implementationAction->setEnabled(enabled);
+    if (enabled && !m_client->isRunning()) {
+        appLoaded();
+    } else if (!enabled && m_client->isRunning()) {
+        m_client->stop();
+    }
+}
+
 void GoplsPlugin::completionRequested(QTextCursor cursor, QString prefix, bool force)
 {
     Q_UNUSED(cursor);
-    if (!m_ready) {
+    if (!m_useFeatures || !m_ready) {
         return;
     }
     LiteApi::IEditor *editor = m_liteApp->editorManager()->currentEditor();
@@ -639,6 +693,7 @@ void GoplsPlugin::addEditorActions(LiteApi::IEditor *editor)
 
 void GoplsPlugin::requestLocations(const QString &method)
 {
+    if (!m_useFeatures) return;
     LiteApi::IEditor *editor = m_liteApp->editorManager()->currentEditor();
     LiteApi::ITextEditor *textEditor = LiteApi::getTextEditor(editor);
     if (!m_ready || !isGoEditor(editor) || !textEditor) {
@@ -697,7 +752,7 @@ QString GoplsPlugin::markupText(const QJsonValue &value) const
 
 void GoplsPlugin::hoverRequested(const QTextCursor &cursor, const QPoint &position, bool navigation)
 {
-    if (!m_ready || navigation) {
+    if (!m_useFeatures || !m_ready || navigation) {
         return;
     }
     LiteApi::ILiteEditor *liteEditor = qobject_cast<LiteApi::ILiteEditor*>(sender());
@@ -708,6 +763,7 @@ void GoplsPlugin::hoverRequested(const QTextCursor &cursor, const QPoint &positi
 void GoplsPlugin::requestHover(LiteApi::IEditor *editor, const QTextCursor &cursor,
                                const QPoint &position)
 {
+    if (!m_useFeatures) return;
     if (!isGoEditor(editor) || cursor.selectedText().trimmed().isEmpty()) {
         int oldId = m_pendingHovers.take(editor);
         if (oldId) {
@@ -736,6 +792,7 @@ void GoplsPlugin::requestHover(LiteApi::IEditor *editor, const QTextCursor &curs
 
 void GoplsPlugin::requestSignatureHelp(LiteApi::IEditor *editor)
 {
+    if (!m_useFeatures) return;
     LiteApi::ITextEditor *textEditor = LiteApi::getTextEditor(editor);
     if (!textEditor) return;
     QTextCursor cursor = textEditor->textCursor();

--- a/liteidex/src/plugins/gopls/goplsplugin.h
+++ b/liteidex/src/plugins/gopls/goplsplugin.h
@@ -51,10 +51,11 @@ private slots:
     void completionAccepted(const QString &text, const QString &kind, const QString &info);
     void workspaceChanged();
     void environmentChanged(LiteApi::IEnv *environment);
+    void applyOption(const QString &option);
 
 private:
     QString workspaceRoot() const;
-    void setLegacyCompletionEnabled(bool enabled);
+    void configureGocodeCompletion(LiteApi::IEditor *editor, bool enabled);
     bool isGoEditor(LiteApi::IEditor *editor) const;
     QString documentUri(LiteApi::IEditor *editor) const;
     void openDocument(LiteApi::IEditor *editor);
@@ -101,6 +102,7 @@ private:
     QHash<int,LiteApi::IEditor*> m_editRequestEditors;
     QHash<QObject*,QHash<QString,QJsonArray> > m_completionAdditionalEdits;
     bool m_appLoaded;
+    bool m_useFeatures;
 };
 
 class PluginFactory : public LiteApi::PluginFactoryT<GoplsPlugin>


### PR DESCRIPTION
## Summary
- add a gopls option to enable completion, hover information, and navigation
- keep gocode as the default completion implementation
- switch completer ownership at runtime and restart gopls when projects change
- restore the historical gocode implementation

## Verification
- git diff --check
- Qt 6 qmake compilation reached plugin link stage; local link is blocked by existing Qt5/Qt6 build-cache mismatch.