### PR TITLE
fix: support column locations in output navigation

### DIFF
--- a/liteidex/src/liteapp/liteapp.cpp
+++ b/liteidex/src/liteapp/liteapp.cpp
@@ -1076,7 +1076,7 @@ void LiteApp::dbclickLogOutput(QTextCursor cur)
 {
     //QRegExp rep("(\\w?:?[\\w\\d_@\\-\\\\/\\.]+):(\\d+):");
     QString text = cur.block().text().trimmed();
-    QRegExp rep("([\\w\\.\\-~/\\\\]+):(\\d+)(?::(\\d+))?");
+    QRegExp rep("([\\w\\.\\-~/\\\\]+):(\\d+)(:(\\d+))?");
     int index = 0;
     QString fileName;
     int line = 0;
@@ -1101,7 +1101,7 @@ void LiteApp::dbclickLogOutput(QTextCursor cur)
             if (QFileInfo::exists(path)) {
                 fileName = path;
                 line = rep.cap(2).toInt();
-                column = rep.cap(3).toInt();
+                column = rep.cap(4).toInt();
                 break;
             }
         }


### PR DESCRIPTION
修复 Output 窗口中带列号的编译错误位置无法双击跳转的问题。\n\n现在可正确解析 file:line:column 格式，并定位到对应行列。