### PR TITLE
gopls: add optional diagnostics display

### DIFF
--- a/liteidex/src/plugins/gopls/gopls_global.h
+++ b/liteidex/src/plugins/gopls/gopls_global.h
@@ -2,6 +2,7 @@
 #define GOPLS_GLOBAL_H
 
 #define GOPLS_USE_FEATURES "gopls/usefeatures"
+#define GOPLS_SHOW_DIAGNOSTICS "gopls/showdiagnostics"
 #define OPTION_GOPLS "option/gopls"
 
 #endif // GOPLS_GLOBAL_H

--- a/liteidex/src/plugins/gopls/goplsoption.cpp
+++ b/liteidex/src/plugins/gopls/goplsoption.cpp
@@ -21,9 +21,11 @@ QString GoplsOption::mimeType() const { return OPTION_GOPLS; }
 void GoplsOption::load()
 {
     ui->enableCheckBox->setChecked(m_liteApp->settings()->value(GOPLS_USE_FEATURES, false).toBool());
+    ui->diagnosticsCheckBox->setChecked(m_liteApp->settings()->value(GOPLS_SHOW_DIAGNOSTICS, false).toBool());
 }
 
 void GoplsOption::save()
 {
     m_liteApp->settings()->setValue(GOPLS_USE_FEATURES, ui->enableCheckBox->isChecked());
+    m_liteApp->settings()->setValue(GOPLS_SHOW_DIAGNOSTICS, ui->diagnosticsCheckBox->isChecked());
 }

--- a/liteidex/src/plugins/gopls/goplsoption.ui
+++ b/liteidex/src/plugins/gopls/goplsoption.ui
@@ -12,6 +12,11 @@
         <property name="text"><string>Use gopls for code completion, mouse information and navigation</string></property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="diagnosticsCheckBox">
+        <property name="text"><string>Show diagnostics from gopls</string></property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/liteidex/src/plugins/gopls/goplsplugin.cpp
+++ b/liteidex/src/plugins/gopls/goplsplugin.cpp
@@ -82,7 +82,7 @@ static QString goplsMarkdownToText(QString text)
 GoplsPlugin::GoplsPlugin() : m_liteApp(0), m_client(0), m_completer(0), m_ready(false),
     m_restartClient(false),
     m_searchResults(0), m_definitionAction(0), m_referencesAction(0), m_implementationAction(0)
-    , m_renameAction(0), m_formatAction(0), m_organizeImportsAction(0), m_appLoaded(false), m_loggedProgram(false), m_useFeatures(false)
+    , m_renameAction(0), m_formatAction(0), m_organizeImportsAction(0), m_appLoaded(false), m_loggedProgram(false), m_useFeatures(false), m_showDiagnostics(false)
 {
 }
 
@@ -98,6 +98,7 @@ bool GoplsPlugin::load(LiteApi::IApplication *app)
 {
     m_liteApp = app;
     m_useFeatures = app->settings()->value(GOPLS_USE_FEATURES,false).toBool();
+    m_showDiagnostics = app->settings()->value(GOPLS_SHOW_DIAGNOSTICS,false).toBool();
     app->optionManager()->addFactory(new GoplsOptionFactory(app,this));
     m_client = new GoplsClient(this);
     m_searchResults = new GoplsSearchResults(this);
@@ -303,6 +304,18 @@ void GoplsPlugin::clientStopped()
 void GoplsPlugin::applyOption(const QString &option)
 {
     if (option != OPTION_GOPLS) return;
+    bool showDiagnostics = m_liteApp->settings()->value(GOPLS_SHOW_DIAGNOSTICS,false).toBool();
+    if (showDiagnostics != m_showDiagnostics) {
+        m_showDiagnostics = showDiagnostics;
+        if (!showDiagnostics) {
+            foreach (LiteApi::IEditor *editor, m_liteApp->editorManager()->editorList()) {
+                LiteApi::ILiteEditor *liteEditor = LiteApi::getLiteEditor(editor);
+                if (liteEditor) {
+                    liteEditor->clearAllNavigateMark(LiteApi::EditorNavigateBad,"gopls");
+                }
+            }
+        }
+    }
     bool enabled = m_liteApp->settings()->value(GOPLS_USE_FEATURES,false).toBool();
     if (enabled == m_useFeatures) return;
     m_useFeatures = enabled;
@@ -966,6 +979,9 @@ void GoplsPlugin::clientNotification(const QString &method, const QJsonValue &pa
         return;
     }
     liteEditor->clearAllNavigateMark(LiteApi::EditorNavigateBad,"gopls");
+    if (!m_showDiagnostics) {
+        return;
+    }
     foreach (QJsonValue value, params.value("diagnostics").toArray()) {
         QJsonObject diagnostic = value.toObject();
         QJsonObject start = diagnostic.value("range").toObject().value("start").toObject();

--- a/liteidex/src/plugins/gopls/goplsplugin.h
+++ b/liteidex/src/plugins/gopls/goplsplugin.h
@@ -111,6 +111,7 @@ private:
     bool m_appLoaded;
     bool m_loggedProgram;
     bool m_useFeatures;
+    bool m_showDiagnostics;
     QString m_workspaceKey;
     QString m_restartReason;
     QSet<QString> m_metadataWarnings;


### PR DESCRIPTION
## Summary

- Add a gopls option to show diagnostics in the editor
- Keep diagnostics hidden by default
- Clear existing gopls diagnostic marks when the option is disabled

## Verification

- `make -C liteidex/build/Qt5-Release/src/plugins/gopls -j2`