### PR TITLE
liteapp: collapse folders after closing editors

### DIFF
--- a/liteidex/src/liteapp/multifolderwindow.cpp
+++ b/liteidex/src/liteapp/multifolderwindow.cpp
@@ -51,6 +51,7 @@ MultiFolderWindow::MultiFolderWindow(LiteApi::IApplication *app, QObject *parent
     connect(m_folderListView,SIGNAL(doubleClicked(QModelIndex)),this,SLOT(doubleClickedFolderView(QModelIndex)));
     connect(m_folderListView,SIGNAL(enterKeyPressed(QModelIndex)),this,SLOT(enterKeyPressedFolderView(QModelIndex)));
     connect(m_liteApp->editorManager(),SIGNAL(currentEditorChanged(LiteApi::IEditor*)),this,SLOT(currentEditorChanged(LiteApi::IEditor*)));
+    connect(m_liteApp->editorManager(),SIGNAL(editorAboutToClose(LiteApi::IEditor*)),this,SLOT(editorAboutToClose(LiteApi::IEditor*)));
 }
 
 MultiFolderWindow::~MultiFolderWindow()
@@ -166,6 +167,28 @@ void MultiFolderWindow::currentEditorChanged(LiteApi::IEditor *editor)
     m_folderListView->scrollTo(index,QAbstractItemView::EnsureVisible);
     m_folderListView->clearSelection();
     m_folderListView->setCurrentIndex(index);
+}
+
+void MultiFolderWindow::editorAboutToClose(LiteApi::IEditor *editor)
+{
+    if (!m_bSyncEditor || !editor || editor->filePath().isEmpty()) {
+        return;
+    }
+
+    QString folderPath = QFileInfo(editor->filePath()).absolutePath();
+    foreach (LiteApi::IEditor *openEditor, m_liteApp->editorManager()->editorList()) {
+        if (openEditor != editor && !openEditor->filePath().isEmpty()
+                && QFileInfo(openEditor->filePath()).absolutePath() == folderPath) {
+            return;
+        }
+    }
+
+    QList<QModelIndex> indexes = m_folderListView->indexForPath(folderPath);
+    foreach (const QModelIndex &index, indexes) {
+        if (index.isValid()) {
+            m_folderListView->setExpanded(index, false);
+        }
+    }
 }
 
 void MultiFolderWindow::aboutToShowFolderContextMenu(QMenu *menu, LiteApi::FILESYSTEM_CONTEXT_FLAG flag, const QFileInfo &info)

--- a/liteidex/src/liteapp/multifolderwindow.h
+++ b/liteidex/src/liteapp/multifolderwindow.h
@@ -47,6 +47,7 @@ public slots:
     void doubleClickedFolderView(const QModelIndex &index);
     void enterKeyPressedFolderView(const QModelIndex &index);
     void currentEditorChanged(LiteApi::IEditor *editor);
+    void editorAboutToClose(LiteApi::IEditor *editor);
     void aboutToShowFolderContextMenu(QMenu *menu, LiteApi::FILESYSTEM_CONTEXT_FLAG flag, const QFileInfo &info);
 protected:
     LiteApi::IApplication *m_liteApp;

--- a/liteidex/src/liteapp/splitfolderwindow.cpp
+++ b/liteidex/src/liteapp/splitfolderwindow.cpp
@@ -71,6 +71,7 @@ SplitFolderWindow::SplitFolderWindow(IApplication *app, QObject *parent)
     connect(m_tree,SIGNAL(reloadFolderIndex(QModelIndex)),this,SLOT(reloadFolderIndex(QModelIndex)));
 
     connect(m_liteApp->editorManager(),SIGNAL(currentEditorChanged(LiteApi::IEditor*)),this,SLOT(currentEditorChanged(LiteApi::IEditor*)));
+    connect(m_liteApp->editorManager(),SIGNAL(editorAboutToClose(LiteApi::IEditor*)),this,SLOT(editorAboutToClose(LiteApi::IEditor*)));
 
     QByteArray state = m_liteApp->settings()->value("LiteApp/BoxFolderSplitter").toByteArray();
     m_spliter->restoreState(state);
@@ -239,6 +240,29 @@ void SplitFolderWindow::currentEditorChanged(IEditor *editor)
             m_tree->setCurrentIndex(m_tree->model()->index(i,0));
             m_stacked->setCurrentIndex(i);
             return;
+        }
+    }
+}
+
+void SplitFolderWindow::editorAboutToClose(IEditor *editor)
+{
+    if (!m_bSyncEditor || !editor || editor->filePath().isEmpty()) {
+        return;
+    }
+
+    QString folderPath = QFileInfo(editor->filePath()).absolutePath();
+    foreach (IEditor *openEditor, m_liteApp->editorManager()->editorList()) {
+        if (openEditor != editor && !openEditor->filePath().isEmpty()
+                && QFileInfo(openEditor->filePath()).absolutePath() == folderPath) {
+            return;
+        }
+    }
+
+    for (int i = 0; i < m_stacked->count(); ++i) {
+        FolderView *view = (FolderView*)m_stacked->widget(i);
+        QModelIndex index = view->indexForPath(QDir::toNativeSeparators(folderPath));
+        if (index.isValid()) {
+            view->setExpanded(index, false);
         }
     }
 }

--- a/liteidex/src/liteapp/splitfolderwindow.h
+++ b/liteidex/src/liteapp/splitfolderwindow.h
@@ -52,6 +52,7 @@ public slots:
     void closeFolderIndex(const QModelIndex &index);
     void reloadFolderIndex(const QModelIndex &index);
     void currentEditorChanged(LiteApi::IEditor *editor);
+    void editorAboutToClose(LiteApi::IEditor *editor);
     void doubleClickedFolderView(const QModelIndex &index);
     void enterKeyPressedFolderView(const QModelIndex &index);
     void aboutToShowFolderContextMenu(QMenu *menu, LiteApi::FILESYSTEM_CONTEXT_FLAG flag, const QFileInfo &info);


### PR DESCRIPTION
## Summary

- Collapse the closed editor's folder in the project directory view when file tracking is enabled
- Keep the folder expanded while another file in the same folder remains open

## Verification

- `make -C liteidex/build/Qt5-Release/src/liteapp -j2`